### PR TITLE
Feature/bpt x1 sip integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,21 @@ __pycache__/
 *.pyc
 *.pyo
 *.DS_Store
+*.log
+*.zip
+*.pcap
+*.pcapng
 
+# Local-only maintainer
+.local/
+.history/
+.claude/
+AGENT_PROMPT.md
+CLAUDE.md
+skills/
+.planning/
+
+# Raw research artifacts and captures
+tmp/
+systemlogs/
+docs/logs/

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@
 - Log in to **CAME Connect** and control your gate/automation
 - **Real-time updates** via WebSocket (no periodic polling after startup)
 - Exposes a **Cover** entity (`cover.gate`) with **open / close / stop**
+- Optional **Open Door** and discovered **AUX** buttons for BPT/X1 intercom systems
 - Status sensors: Phase, Position (%), Hub Online, Hub Last Seen, Error
 - Config Flow (UI) — no YAML required
-- Options for Redirect URI and WebSocket URL
+- Options for Redirect URI, WebSocket URL, and optional BPT door-open settings
 
 > **Note:** API and endpoints are based on reverse-engineered calls used by CAME’s web app. CAME can change them at any time.
+> BPT setup details are documented in [docs/user/bpt-door-setup.md](/home/d0m/Projects/gtapps/came_connect/docs/user/bpt-door-setup.md).
 
 ---
 
@@ -32,6 +34,14 @@
   - Found at the end of the URL after selecting your site and device in the CAME Connect web app, e.g. https://app.cameconnect.net/home/devices/XXXXXX (typically 6 digits)
 - A compatible **CAME** controller that works with CAME Connect
   - ⚠️ confirmed on **ZLX24SA board** (other models untested)
+
+## ℹ️ Compatibility
+
+- Gate and automation control is the main public feature of this integration.
+- BPT/X1 intercom support has been validated on setups using **XTS7-style**
+  indoor monitors.
+- Other BPT/X1 or video-entry variants may still work, but they should be
+  treated as compatible-on-test rather than guaranteed.
 
 ---
 
@@ -73,7 +83,7 @@ No YAML configuration is supported.
 CAME does not provide a public developer portal. Instead, we reuse the same OAuth
 client credentials that the web app uses. You can extract them yourself:
 
-1. Open [https://app.cameconnect.net](https://app.cameconnect.net)) in a desktop browser but **don't** log in yet.
+1. Open [https://app.cameconnect.net](https://app.cameconnect.net) in a desktop browser but **don't** log in yet.
 2. Open your browser’s **Developer Tools → Network** tab.
 3. **Log in** to the web application
 4. Look for a request to an endpoint like:
@@ -128,19 +138,191 @@ After initial setup, you can tweak settings from the integration’s Options:
 2. Find **CAME Connect** in your list of integrations.
 3. Click the **cog icon (⚙️)** on the integration page.
 
-You will see two configurable options:
+The options flow is split into separate branches:
 
-- **Redirect URI**
-  The URI used when authenticating with the CAME Connect cloud.
-  Default: `https://app.cameconnect.net/role`
+- **Cloud settings**
+  Contains `Redirect URI` and `Realtime WebSocket URL`.
+  Most users should leave both values at their defaults.
 
-In most cases you don’t need to change this unless CAME updates their API endpoints.
+- **BPT/X1 door button**
+  Only relevant for BPT/X1 intercom units such as XTS7 indoor monitors.
+  Normal setup usually needs only:
+  - **Mobile App SIP password**
+  - optionally **Mobile App slot / SIP user** if more than one `Mobile App` slot is enabled on the account
 
-- **WebSocket URL**
-  The realtime events endpoint used to receive live state updates (no polling).
-  Default: `wss://app.cameconnect.net/api/events-real-time`
+  When live discovery is available, the options flow now shows:
+  - a dropdown of valid Mobile App slots instead of a free-text SIP user field
+  - a read-only discovery summary with the resolved intercom name, entry panel, door label, selected slot, and token source
 
-You should not have to change either of these - only do so if you know what you are doing.
+- **Advanced BPT overrides**
+  Contains the HA1, legacy device token, and low-level protocol overrides.
+  These are normally auto-discovered from `/api/sipaccounts` plus the site/device metadata chain, so leave them blank unless autodiscovery fails or you are forcing known-good values from traces.
+
+---
+
+## 📟 BPT/X1 Intercom Setup
+
+This section is only relevant for BPT/X1 intercom units such as the **XTS7**.
+If you only want gate control, you can skip it.
+
+### Recommended Approach
+
+The cleanest setup is to use a **separate `cameconnect.net` account** for Home Assistant's
+BPT/X1 access, so it can be tied to its own dedicated **Mobile App slot** on the unit.
+
+That gives you:
+
+- a dedicated SIP user for Home Assistant
+- a separate Mobile App password for the X1 path
+- less risk of interfering with the mobile app slot you use on your personal phone
+
+### Before You Start
+
+You should already have the normal CAME integration working first:
+
+- the integration added in Home Assistant
+- your main CAME account credentials working
+- the correct CAME device visible in Home Assistant
+
+### Which Account Should I Use?
+
+For normal gate control, you can use your usual owner or administrator CAME
+account.
+
+For BPT/X1, the recommended setup is:
+
+- keep your main account for day-to-day app use
+- create a **separate invited `cameconnect.net` account** for Home Assistant
+- bind that account to its own dedicated **Mobile App slot**
+
+This avoids reusing the same Mobile App slot that your phone depends on.
+
+### Step 1: Create a Dedicated CAME Account for Home Assistant
+
+Create a second `cameconnect.net` account that you want Home Assistant to use for the
+X1 integration path.
+
+### Step 2: Find the Unit Local IP
+
+If you do not know the local IP of your XTS7 unit:
+
+1. Go to the **XTS7 panel**
+2. Open **Settings**
+3. Open **Advanced**
+4. Open **Network**
+5. Note the unit IP address
+
+### Step 3: Set the Mobile App Password on the Unit
+
+Open the unit web interface in your browser:
+
+```text
+http://<your-unit-ip>
+```
+
+Then:
+
+1. Select **Installer**
+2. Enter the installer password
+   - for **XTS7**, the default is typically `112233`
+   - for other units, use your actual installer password
+3. Open **Credentials**
+4. Choose the **Mobile App** slot you want to dedicate to Home Assistant
+5. Set a password for that Mobile App slot
+6. Note the slot's **SIP ID / SIP user**, for example `00700100001`
+
+You will need:
+
+- the **Mobile App SIP password** you just set
+- the **Mobile App SIP user** if you want to force a specific slot or if multiple slots are enabled
+
+Safety note:
+
+- changing the password of a Mobile App slot can affect any phone or integration
+  already using that same slot
+- this is another reason to dedicate a separate Mobile App slot to Home Assistant
+
+### Step 4: Invite the Dedicated Account to the Correct Video Entry Unit
+
+Using the normal **Came Access** mobile app on Android or iPhone, sign in with the
+administrator or owner account that already manages the system.
+
+Then go to:
+
+1. **Profile**
+2. **Installations** or **Systems**
+3. Select your system
+4. Select the **Video Entry unit** you want to grant access to
+5. Edit the **Mobile App** slot you prepared for Home Assistant
+6. Send the invite to the new dedicated `cameconnect.net` account
+
+Make sure you remember which **Mobile App SIP user** belongs to that slot.
+
+### Step 5: Accept the Invite in the Mobile App
+
+Now sign in to the **Came Access** Android or iOS app with the **new dedicated account**
+and accept the invitation.
+
+This step matters because the account must actually be linked to the system and the
+selected video entry unit before Home Assistant can use that slot reliably.
+
+### Step 6: Configure Home Assistant
+
+In Home Assistant:
+
+1. Open **Settings -> Devices & Services**
+2. Open the **CAME Connect** integration
+3. Open **Options**
+4. Open **BPT/X1 door button**
+
+Important:
+
+- the integration entry that should control the BPT/X1 device must use the
+  CAME account that was invited to that Mobile App slot
+- if you create a dedicated `cameconnect.net` account for Home Assistant, use
+  that account's CAME username and password in the integration
+
+In normal setups, you usually only need:
+
+- **Mobile App SIP password**
+- optionally **Mobile App slot / SIP user**
+
+Use **Mobile App slot / SIP user** when:
+
+- you want to force the exact slot you prepared
+- your unit has multiple enabled Mobile App slots
+- the options flow asks you to choose between multiple discovered slots
+
+Leave **Advanced BPT overrides** blank unless you are troubleshooting.
+
+### What Home Assistant Should Discover
+
+When setup succeeds, the integration should:
+
+- resolve the intercom and entry-panel metadata automatically
+- keep the normal gate entities on the main **CAME Connect** device
+- create a separate **BPT/X1** child device
+- expose **Open Door**
+- expose one button per discovered **AUX** feature, when available
+
+If live discovery is available, the options flow should also show:
+
+- the selected Mobile App slot
+- the resolved intercom name
+- the entry panel name
+- the door action label
+
+### What Should Appear After Setup?
+
+In Home Assistant you should normally see:
+
+- one main **CAME Connect** device for gate or automation control
+- one **BPT/X1** child device when intercom setup is enabled
+- `Open Door` on that BPT/X1 device
+- one or more discovered `AUX` buttons on that same BPT/X1 device when the
+  unit exposes AUX functions
+
+For more detail, see [docs/user/bpt-door-setup.md](/home/d0m/Projects/gtapps/came_connect/docs/user/bpt-door-setup.md).
 
 ---
 
@@ -150,6 +332,13 @@ You should not have to change either of these - only do so if you know what you 
 
 - **Gate** (`cover.gate`) — supports **open**, **close**, **stop**  
   _Attributes:_ `phase` (code), `phase_name` (Open/Closed/Opening/Closing/Stopped), `direction` (Opening/Closing), `last_pos`, `raw_data`.
+
+### Button
+
+- **Open Door** (`button.open_door`) — sends the BPT/X1 cloud SIP open-door command.
+  _Attributes:_ `last_run`, `last_register_status`, `last_message_status`, `last_error`, SIP addressing fields.
+- **AUX buttons** — one button per discovered BPT/X1 AUX feature on the intercom device.
+  Labels come from the unit metadata when available.
 
 ### Sensors
 
@@ -169,11 +358,12 @@ You should not have to change either of these - only do so if you know what you 
 
 ## 🛠️ Services
 
-This integration does **not** add custom services. Use the standard Home Assistant **cover** services:
+This integration does **not** add custom services. Use the standard Home Assistant **cover** and **button** services:
 
 - `cover.open_cover` — open the gate
 - `cover.close_cover` — close the gate
 - `cover.stop_cover` — stop movement
+- `button.press` — trigger the optional BPT open-door button
 
 **Examples**
 
@@ -192,6 +382,35 @@ target:
 service: cover.stop_cover
 target:
   entity_id: cover.gate
+
+# Trigger the BPT door-open action
+service: button.press
+target:
+  entity_id: button.open_door
+```
+
+### Automation Example: X1 Door Or AUX
+
+Entity IDs depend on your naming in Home Assistant, but the action is always
+the standard `button.press` service.
+
+```yaml
+automation:
+  - alias: Trigger X1 door
+    triggers: []
+    conditions: []
+    actions:
+      - action: button.press
+        target:
+          entity_id: button.open_door
+
+  - alias: Trigger X1 AUX output
+    triggers: []
+    conditions: []
+    actions:
+      - action: button.press
+        target:
+          entity_id: button.aux_1
 ```
 
 ---
@@ -220,6 +439,22 @@ Your OAuth client is registered to a different URL.
 
 - Verify **Client ID/Secret**, **Username/Password**, and **Device ID**.
 - Confirm the device is visible in the CAME Connect app under the same account.
+
+### BPT/X1 device or buttons do not appear
+
+- Confirm the invited account accepted the invite in the **Came Access** app.
+- Confirm the integration is using that same invited CAME account.
+- Re-open **Options → BPT/X1 door button** and verify the **Mobile App SIP password**.
+- If the unit has multiple Mobile App slots, set **Mobile App slot / SIP user**
+  explicitly.
+
+### Gate works but Open Door does not
+
+- Recheck the Mobile App slot password in the unit web interface.
+- Confirm you edited the correct **Mobile App** slot for the invited account.
+- Confirm the **Mobile App SIP user** you noted from the unit matches the slot
+  assigned to that invited account.
+- Leave advanced overrides blank unless you are troubleshooting a known issue.
 
 ### Enable debug logging
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - Options for Redirect URI, WebSocket URL, and optional BPT door-open settings
 
 > **Note:** API and endpoints are based on reverse-engineered calls used by CAME’s web app. CAME can change them at any time.
-> BPT setup details are documented in [docs/user/bpt-door-setup.md](/home/d0m/Projects/gtapps/came_connect/docs/user/bpt-door-setup.md).
+> BPT setup details are documented in [docs/user/bpt-door-setup.md].
 
 ---
 
@@ -50,7 +50,7 @@
 ### Option A — HACS (Custom repository)
 
 1. In HACS → **Integrations** → 3-dot menu → **Custom repositories**.
-2. Repository: `https://github.com/sdeagh/came_connect`  
+2. Repository: `https://github.com/sdeagh/came_connect`
    Category: **Integration** → **Add**.
 3. Install **CAME Connect**.
 4. **Restart Home Assistant**.
@@ -322,7 +322,7 @@ In Home Assistant you should normally see:
 - one or more discovered `AUX` buttons on that same BPT/X1 device when the
   unit exposes AUX functions
 
-For more detail, see [docs/user/bpt-door-setup.md](/home/d0m/Projects/gtapps/came_connect/docs/user/bpt-door-setup.md).
+For more detail, see [docs/user/bpt-door-setup.md].
 
 ---
 
@@ -330,7 +330,7 @@ For more detail, see [docs/user/bpt-door-setup.md](/home/d0m/Projects/gtapps/cam
 
 ### Cover
 
-- **Gate** (`cover.gate`) — supports **open**, **close**, **stop**  
+- **Gate** (`cover.gate`) — supports **open**, **close**, **stop**
   _Attributes:_ `phase` (code), `phase_name` (Open/Closed/Opening/Closing/Stopped), `direction` (Opening/Closing), `last_pos`, `raw_data`.
 
 ### Button
@@ -488,25 +488,25 @@ logger:
 
 ## 🧭 Roadmap
 
-- **Multi-device support**  
+- **Multi-device support**
   Discover and add multiple CAME devices under one account; device picker in the config flow.
 
-- **Richer entities**  
+- **Richer entities**
   Expose obstruction/photocell status (if available), fault codes mapped to friendly text, cycle/runtime counters.
 
-- **WebSocket resilience**  
+- **WebSocket resilience**
   Heartbeat (ping/pong), stale-connection watchdog, and proactive token refresh before expiry.
 
-- **Smarter setup**  
+- **Smarter setup**
   Auto-detect the correct Redirect URI, verify WebSocket URL, and fetch Device IDs automatically.
 
-- **Diagnostics & logging**  
+- **Diagnostics & logging**
   One-click diagnostics download and a toggle to surface WS frames safely when debugging.
 
-- **Localization & docs**  
+- **Localization & docs**
   More translations and clearer setup/FAQ guides.
 
-- **Testing & quality**  
+- **Testing & quality**
   Add unit/integration tests and CI, and prepare for HACS default store inclusion.
 
 Have a feature request? Please open a GitHub issue.

--- a/custom_components/came_connect/api.py
+++ b/custom_components/came_connect/api.py
@@ -6,17 +6,42 @@ import secrets
 import string
 import time
 import asyncio
+import socket
+import ssl
 import aiohttp
 import logging
 import json
 import contextlib
+import re
+import uuid
 
-from urllib.parse import quote, urlencode
+from dataclasses import dataclass
+from urllib.parse import urlencode
 
-from typing import Any, Dict, Optional, Callable, Awaitable
+from typing import Any, Dict, Optional, Callable, Awaitable, Mapping
 
-from .const import API_BASE
+from .const import (
+    API_BASE,
+    CONF_BPT_DEVICE_TOKEN,
+    CONF_BPT_KEYCODE,
+    CONF_BPT_PANEL_ADDR,
+    CONF_BPT_SIP_HA1,
+    CONF_BPT_SIP_PASSWORD,
+    CONF_BPT_SIP_USER,
+    CONF_BPT_SRC_ADDR,
+    CONF_BPT_SUBJECT_LABEL,
+    CONF_BPT_TARGET_USER,
+    DEFAULT_BPT_APP_NAME,
+    DEFAULT_BPT_AUTH_PASSWORD_PREFIX,
+    DEFAULT_BPT_LANG,
+    DEFAULT_BPT_OS_TYPE,
+    DEFAULT_BPT_PANEL_ADDR,
+    DEFAULT_BPT_SIP_PROXY_HOST,
+    DEFAULT_BPT_SIP_PROXY_PORT,
+    DEFAULT_BPT_TARGET_USER,
+)
 
+_LOGGER = logging.getLogger(__name__)
 WS_LOGGER = logging.getLogger(__name__ + ".ws")  
 
 class CameAuthError(Exception):
@@ -27,6 +52,568 @@ class CameApiError(Exception):
 
 class CameRateLimitError(Exception):
     """429 rate limit (we'll use this later)."""
+
+
+MOBILE_APP_FEATURE_ID = 4
+OPEN_DOOR_FEATURE_ID = 2
+ENTRY_PANEL_AUX_FEATURE_IDS = tuple(range(8, 18))
+ENTRY_PANEL_MODULE_ID = 1
+UNIT_MODULE_ID = 2
+SETTING_SIP_USER = 1
+SETTING_L3_ADDR = 2
+SETTING_TARGET_USER = 3
+SETTING_PANEL_ADDR = 4
+SETTING_ENABLED = 5
+SETTING_ICON = 6
+
+
+@dataclass(frozen=True)
+class BptDiscovery:
+    keycode: str
+    sip_user: str
+    src_addr: str
+    subject_label: str
+    target_user: str
+    panel_addr: str
+    device_token: str = ""
+
+
+@dataclass(frozen=True)
+class BptMobileSlot:
+    sip_user: str
+    src_addr: str
+    subject_label: str
+
+
+@dataclass(frozen=True)
+class BptSipAccount:
+    device_token: str
+    sip_user: str
+    src_addr: str
+    keycode: str
+    sip_password: str | None = None
+
+
+@dataclass(frozen=True)
+class BptDoorConfig:
+    keycode: str
+    sip_user: str
+    src_addr: str
+    subject_label: str
+    device_token: str
+    sip_password: str | None = None
+    sip_ha1: str | None = None
+    target_user: str = DEFAULT_BPT_TARGET_USER
+    panel_addr: str = DEFAULT_BPT_PANEL_ADDR
+    app_name: str = DEFAULT_BPT_APP_NAME
+    os_type: str = DEFAULT_BPT_OS_TYPE
+    app_lang: str = DEFAULT_BPT_LANG
+    proxy_host: str = DEFAULT_BPT_SIP_PROXY_HOST
+    proxy_port: int = DEFAULT_BPT_SIP_PROXY_PORT
+    auth_password_prefix: str = DEFAULT_BPT_AUTH_PASSWORD_PREFIX
+
+    @property
+    def sip_domain(self) -> str:
+        return f"{self.keycode}.xip.cameconnect.net"
+
+    @property
+    def auth_password(self) -> str | None:
+        if not self.sip_password:
+            return None
+        return f"{self.auth_password_prefix}{self.sip_password}"
+
+    @staticmethod
+    def has_credentials(data: Mapping[str, Any]) -> bool:
+        sip_password = data.get(CONF_BPT_SIP_PASSWORD)
+        sip_ha1 = data.get(CONF_BPT_SIP_HA1)
+        return bool(sip_password or sip_ha1)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any],
+        discovery: BptDiscovery | None = None,
+    ) -> "BptDoorConfig | None":
+        def _clean(key: str, default: str = "") -> str:
+            value = data.get(key, default)
+            return value.strip() if isinstance(value, str) else default
+
+        keycode = _clean(CONF_BPT_KEYCODE) or (discovery.keycode if discovery else "")
+        sip_user = _clean(CONF_BPT_SIP_USER) or (discovery.sip_user if discovery else "")
+        sip_password = _clean(CONF_BPT_SIP_PASSWORD)
+        sip_ha1 = _clean(CONF_BPT_SIP_HA1)
+        src_addr = _clean(CONF_BPT_SRC_ADDR) or (discovery.src_addr if discovery else "")
+        subject_label = _clean(CONF_BPT_SUBJECT_LABEL) or (discovery.subject_label if discovery else "")
+        device_token = _clean(CONF_BPT_DEVICE_TOKEN) or (discovery.device_token if discovery else "")
+        target_user = _clean(CONF_BPT_TARGET_USER) or (
+            discovery.target_user if discovery and discovery.target_user else DEFAULT_BPT_TARGET_USER
+        )
+        panel_addr = _clean(CONF_BPT_PANEL_ADDR) or (
+            discovery.panel_addr if discovery and discovery.panel_addr else DEFAULT_BPT_PANEL_ADDR
+        )
+
+        if not all([keycode, sip_user, src_addr, subject_label, device_token]):
+            return None
+        if not (sip_password or sip_ha1):
+            return None
+
+        return cls(
+            keycode=keycode,
+            sip_user=sip_user,
+            sip_password=sip_password or None,
+            sip_ha1=sip_ha1 or None,
+            src_addr=src_addr,
+            target_user=target_user,
+            panel_addr=panel_addr,
+            subject_label=subject_label,
+            device_token=device_token,
+        )
+
+
+@dataclass(frozen=True)
+class BptAuxFeature:
+    aux_code: int
+    feature_id: int
+    name: str
+    label: str
+    icon: str | None = None
+
+
+@dataclass(frozen=True)
+class BptDeviceMetadata:
+    device_name: str
+    entry_panel_name: str
+    unit_name: str
+    open_door_label: str
+    aux_features: tuple[BptAuxFeature, ...]
+    model: str
+    manufacturer: str = "CAME"
+
+
+@dataclass(frozen=True)
+class BptResolvedTarget:
+    device_token: str
+    device: Mapping[str, Any]
+    discovery: BptDiscovery
+    sip_account: BptSipAccount | None = None
+
+
+@dataclass(frozen=True)
+class BptSetupPreview:
+    slots: tuple[BptMobileSlot, ...]
+    selected_slot: BptMobileSlot | None
+    metadata: BptDeviceMetadata
+    token_source: str
+
+
+def _coerce_list(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        for key in ("Data", "data", "Items", "items"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _settings_map(settings: Any) -> dict[int, str]:
+    result: dict[int, str] = {}
+    if not isinstance(settings, list):
+        return result
+    for item in settings:
+        if not isinstance(item, dict):
+            continue
+        setting_id = item.get("SettingId")
+        value = item.get("Value")
+        if isinstance(setting_id, int) and value is not None:
+            result[setting_id] = str(value)
+    return result
+
+
+def _display_label(item: Mapping[str, Any], fallback: str = "") -> str:
+    return str(item.get("AliasName") or item.get("Name") or fallback).strip()
+
+
+def _extract_aux_code(
+    *,
+    feature_id: int,
+    name: str,
+    label: str,
+) -> int:
+    for candidate in (name, label):
+        match = re.search(r"(\d+)$", candidate.strip())
+        if match:
+            parsed = int(match.group(1))
+            if parsed > 0:
+                return parsed
+
+    if feature_id in ENTRY_PANEL_AUX_FEATURE_IDS:
+        return feature_id - ENTRY_PANEL_AUX_FEATURE_IDS[0] + 1
+
+    raise CameApiError(f"Unable to determine AUX code for feature {feature_id} ({name or label})")
+
+
+def _find_device_record(devices_payload: Any, device_id: int | str) -> dict[str, Any] | None:
+    wanted = str(device_id)
+    for device in _coerce_list(devices_payload):
+        if str(device.get("DeviceId", "")) == wanted or str(device.get("Id", "")) == wanted:
+            return device
+    return None
+
+
+def _extract_bpt_discovery(
+    device: Mapping[str, Any],
+    *,
+    preferred_sip_user: str = "",
+    preferred_subject_label: str = "",
+    preferred_src_addr: str = "",
+) -> BptDiscovery:
+    keycode = str(device.get("Keycode", "")).strip()
+    if not keycode:
+        raise CameApiError("Missing BPT keycode in device metadata")
+
+    panel_addr = DEFAULT_BPT_PANEL_ADDR
+    target_user = DEFAULT_BPT_TARGET_USER
+
+    modules = device.get("Modules")
+    if not isinstance(modules, list):
+        raise CameApiError("Missing BPT modules in device metadata")
+
+    for module in modules:
+        if not isinstance(module, dict):
+            continue
+        module_id = module.get("ModuleId")
+        module_settings = _settings_map(module.get("Settings"))
+        if module_id == ENTRY_PANEL_MODULE_ID:
+            panel_addr = module_settings.get(SETTING_PANEL_ADDR, panel_addr)
+            target_user = module_settings.get(SETTING_TARGET_USER, target_user)
+
+    mobile_slots = _extract_bpt_mobile_slots(device)
+    if not mobile_slots:
+        raise CameApiError("No enabled BPT mobile app slots found in device metadata")
+
+    selected = _select_bpt_mobile_slot(
+        mobile_slots,
+        preferred_sip_user=preferred_sip_user,
+        preferred_subject_label=preferred_subject_label,
+        preferred_src_addr=preferred_src_addr,
+        allow_empty=False,
+    )
+    assert selected is not None
+
+    return BptDiscovery(
+        keycode=keycode,
+        sip_user=selected.sip_user,
+        src_addr=selected.src_addr,
+        subject_label=selected.subject_label,
+        target_user=target_user,
+        panel_addr=panel_addr,
+    )
+
+
+def _extract_bpt_mobile_slots(device: Mapping[str, Any]) -> list[BptMobileSlot]:
+    mobile_slots: list[BptMobileSlot] = []
+    modules = device.get("Modules")
+    if not isinstance(modules, list):
+        return mobile_slots
+
+    for module in modules:
+        if not isinstance(module, dict):
+            continue
+        features = module.get("Features")
+        if not isinstance(features, list):
+            continue
+        for feature in features:
+            if not isinstance(feature, dict) or feature.get("FeatureId") != MOBILE_APP_FEATURE_ID:
+                continue
+            settings = _settings_map(feature.get("Settings"))
+            sip_user = settings.get(SETTING_SIP_USER, "").strip()
+            src_addr = settings.get(SETTING_L3_ADDR, "").strip()
+            enabled = settings.get(SETTING_ENABLED, "true").strip().lower()
+            if not sip_user or not src_addr or enabled in {"false", "0", "no"}:
+                continue
+            mobile_slots.append(
+                BptMobileSlot(
+                    sip_user=sip_user,
+                    src_addr=src_addr,
+                    subject_label=str(feature.get("AliasName") or feature.get("Name") or sip_user).strip(),
+                )
+            )
+    return mobile_slots
+
+
+def _select_bpt_mobile_slot(
+    mobile_slots: list[BptMobileSlot],
+    *,
+    preferred_sip_user: str = "",
+    preferred_subject_label: str = "",
+    preferred_src_addr: str = "",
+    allow_empty: bool = False,
+) -> BptMobileSlot | None:
+    selected = None
+    if preferred_sip_user:
+        selected = next((item for item in mobile_slots if item.sip_user == preferred_sip_user), None)
+        if selected is None:
+            raise CameApiError(f"BPT SIP user {preferred_sip_user} was not found in device metadata")
+        return selected
+
+    if preferred_src_addr:
+        selected = next((item for item in mobile_slots if item.src_addr == preferred_src_addr), None)
+        if selected is None:
+            raise CameApiError(f"BPT source address {preferred_src_addr} was not found in device metadata")
+        return selected
+
+    if preferred_subject_label:
+        selected = next((item for item in mobile_slots if item.subject_label == preferred_subject_label), None)
+        if selected is None:
+            raise CameApiError(f"BPT subject label {preferred_subject_label} was not found in device metadata")
+        return selected
+
+    if len(mobile_slots) == 1:
+        return mobile_slots[0]
+
+    if allow_empty:
+        return None
+
+    choices = ", ".join(item.sip_user for item in mobile_slots)
+    raise CameApiError(
+        "Multiple enabled BPT mobile app slots were discovered. "
+        f"Set {CONF_BPT_SIP_USER} to choose one of: {choices}"
+    )
+
+
+def _extract_bpt_device_metadata(device: Mapping[str, Any]) -> BptDeviceMetadata:
+    device_name = _display_label(device, "BPT/X1 Intercom")
+    entry_panel_name = "Entry panel"
+    unit_name = device_name
+    open_door_label = "Open Door"
+    aux_features: list[BptAuxFeature] = []
+
+    modules = device.get("Modules")
+    if isinstance(modules, list):
+        for module in modules:
+            if not isinstance(module, dict):
+                continue
+            module_id = module.get("ModuleId")
+            if module_id == ENTRY_PANEL_MODULE_ID:
+                entry_panel_name = _display_label(module, entry_panel_name)
+                features = module.get("Features")
+                if isinstance(features, list):
+                    for feature in features:
+                        if not isinstance(feature, dict):
+                            continue
+                        feature_id = feature.get("FeatureId")
+                        if feature_id == OPEN_DOOR_FEATURE_ID:
+                            open_door_label = _display_label(feature, open_door_label)
+                            continue
+                        if feature_id not in ENTRY_PANEL_AUX_FEATURE_IDS:
+                            continue
+                        settings = _settings_map(feature.get("Settings"))
+                        icon = settings.get(SETTING_ICON, "").strip() or None
+                        aux_name = str(feature.get("Name", "")).strip()
+                        aux_label = _display_label(feature, aux_name)
+                        aux_features.append(
+                            BptAuxFeature(
+                                aux_code=_extract_aux_code(
+                                    feature_id=int(feature_id),
+                                    name=aux_name,
+                                    label=aux_label,
+                                ),
+                                feature_id=int(feature_id),
+                                name=aux_name,
+                                label=aux_label,
+                                icon=icon,
+                            )
+                        )
+            elif module_id == UNIT_MODULE_ID:
+                unit_name = _display_label(module, unit_name)
+
+    plant_type = str(device.get("PlantType", "")).strip()
+    model = f"CAME BPT {plant_type}" if plant_type else "CAME BPT/X1"
+    return BptDeviceMetadata(
+        device_name=device_name,
+        entry_panel_name=entry_panel_name,
+        unit_name=unit_name,
+        open_door_label=open_door_label,
+        aux_features=tuple(aux_features),
+        model=model,
+    )
+
+
+def _extract_bpt_sip_accounts(payload: Any) -> list[BptSipAccount]:
+    accounts: list[BptSipAccount] = []
+    for item in _coerce_list(payload):
+        device_token = str(item.get("DeviceToken", "")).strip()
+        sip_user = str(item.get("SipUserName") or item.get("UserName") or "").strip()
+        src_addr = str(item.get("BptL3Addr") or item.get("L3Address") or "").strip()
+        keycode = str(item.get("Keycode", "")).strip()
+        sip_password = str(item.get("SipPassword", "")).strip() or None
+        if not all([device_token, sip_user, src_addr, keycode]):
+            continue
+        accounts.append(
+            BptSipAccount(
+                device_token=device_token,
+                sip_user=sip_user,
+                src_addr=src_addr,
+                keycode=keycode,
+                sip_password=sip_password,
+            )
+        )
+    return accounts
+
+
+def _filter_bpt_sip_accounts(
+    accounts: list[BptSipAccount],
+    *,
+    preferred_sip_user: str = "",
+    preferred_src_addr: str = "",
+) -> list[BptSipAccount]:
+    if preferred_sip_user:
+        matches = [account for account in accounts if account.sip_user == preferred_sip_user]
+        if not matches:
+            choices = ", ".join(sorted({account.sip_user for account in accounts})) or "none"
+            raise CameApiError(
+                f"BPT SIP user {preferred_sip_user} was not found in /sipaccounts. "
+                f"Available users: {choices}"
+            )
+        return matches
+
+    if preferred_src_addr:
+        matches = [account for account in accounts if account.src_addr == preferred_src_addr]
+        if not matches:
+            choices = ", ".join(sorted({account.src_addr for account in accounts})) or "none"
+            raise CameApiError(
+                f"BPT source address {preferred_src_addr} was not found in /sipaccounts. "
+                f"Available addresses: {choices}"
+            )
+        return matches
+
+    return accounts
+
+
+def _md5(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8")).hexdigest()
+
+
+def _truncate_label(label: str) -> str:
+    return label[:24]
+
+
+def _build_subject(src_addr: str, dst_addr: str, label: str) -> str:
+    return f"{src_addr};{dst_addr};00001;;{_truncate_label(label)}"
+
+
+def _build_open_door_xml(src_addr: str, dst_addr: str) -> str:
+    return (
+        "<BPT_COMMAND><COMMAND><type>OPEN_DOOR</type>"
+        f"<src_addr>{src_addr}</src_addr>"
+        f"<dst_addr>{dst_addr}</dst_addr>"
+        "</COMMAND></BPT_COMMAND>"
+    )
+
+
+def _build_aux_xml(src_addr: str, dst_addr: str, aux_code: int) -> str:
+    return (
+        "<BPT_COMMAND><COMMAND><type>AUX_COMMAND</type>"
+        f"<aux_code>{aux_code}</aux_code>"
+        f"<src_addr>{src_addr}</src_addr>"
+        f"<dst_addr>{dst_addr}</dst_addr>"
+        "</COMMAND></BPT_COMMAND>"
+    )
+
+
+def _digest_response(
+    user: str,
+    password: str | None,
+    realm: str,
+    nonce: str,
+    method: str,
+    uri: str,
+    *,
+    ha1_override: str | None = None,
+    qop: str | None = None,
+    nc: str | None = None,
+    cnonce: str | None = None,
+) -> str:
+    if password is not None:
+        ha1 = _md5(f"{user}:{realm}:{password}")
+    elif ha1_override:
+        ha1 = ha1_override
+    else:
+        raise ValueError("Missing SIP auth secret")
+    ha2 = _md5(f"{method}:{uri}")
+    if qop:
+        return _md5(f"{ha1}:{nonce}:{nc}:{cnonce}:{qop}:{ha2}")
+    return _md5(f"{ha1}:{nonce}:{ha2}")
+
+
+def _parse_digest_challenge(header: str) -> dict[str, str]:
+    _, _, payload = header.partition(":")
+    payload = payload.strip()
+    if payload.lower().startswith("digest "):
+        payload = payload[7:]
+
+    params: dict[str, str] = {}
+    for key, value in re.findall(r'(\w+)=(".*?"|[^,\s]+)', payload):
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        params[key.lower()] = value
+    return params
+
+
+def _pick_qop(qop_value: str) -> str | None:
+    if not qop_value:
+        return None
+    options = [item.strip() for item in qop_value.split(",") if item.strip()]
+    if "auth" in options:
+        return "auth"
+    return options[0] if options else None
+
+
+def _build_digest_auth_header(
+    method_auth: str,
+    challenge: Mapping[str, str],
+    method: str,
+    uri: str,
+    sip_user: str,
+    password: str | None,
+    *,
+    ha1_override: str | None = None,
+) -> str:
+    realm = challenge.get("realm", "")
+    nonce = challenge.get("nonce", "")
+    qop = _pick_qop(challenge.get("qop", ""))
+    nc = "00000001" if qop else None
+    cnonce = uuid.uuid4().hex[:16] if qop else None
+    response = _digest_response(
+        sip_user,
+        password,
+        realm,
+        nonce,
+        method,
+        uri,
+        ha1_override=ha1_override,
+        qop=qop,
+        nc=nc,
+        cnonce=cnonce,
+    )
+
+    parts = [
+        f'{method_auth}: Digest username="{sip_user}"',
+        f'realm="{realm}"',
+        f'nonce="{nonce}"',
+        f'uri="{uri}"',
+        f'response="{response}"',
+        "algorithm=MD5",
+    ]
+    if challenge.get("opaque"):
+        parts.append(f'opaque="{challenge["opaque"]}"')
+    if qop:
+        parts.append(f"qop={qop}")
+        parts.append(f"nc={nc}")
+        parts.append(f'cnonce="{cnonce}"')
+    return ", ".join(parts)
 
 def _basic_header(client_id: str, client_secret: str) -> dict[str, str]:
     token = base64.b64encode(f"{client_id}:{client_secret}".encode("utf-8")).decode("utf-8")
@@ -183,6 +770,572 @@ class CameConnectClient:
         if status not in (200, 202):
             raise RuntimeError(f"command {command_id} failed: {status} {js}")
         return js
+
+    async def async_open_bpt_door(self, config: BptDoorConfig) -> dict[str, Any]:
+        xip_result = await self._async_bpt_xipregister(config)
+        result = await asyncio.to_thread(
+            self._send_bpt_xml_command,
+            config,
+            _build_open_door_xml(config.src_addr, config.panel_addr),
+            _build_subject(config.src_addr, config.panel_addr, config.subject_label),
+        )
+        result.update(xip_result)
+        return result
+
+    async def async_open_bpt_aux(self, config: BptDoorConfig, aux_code: int) -> dict[str, Any]:
+        xip_result = await self._async_bpt_xipregister(config)
+        result = await asyncio.to_thread(
+            self._send_bpt_xml_command,
+            config,
+            _build_aux_xml(config.src_addr, config.panel_addr, aux_code),
+            None,
+        )
+        result["aux_code"] = aux_code
+        result.update(xip_result)
+        return result
+
+    async def _async_bpt_xipregister(self, config: BptDoorConfig) -> dict[str, Any]:
+        xip_status, xip_body = await self._request(
+            "GET",
+            f"{API_BASE}/push/xipregister",
+            params={
+                "sipUri": config.sip_user,
+                "sipDomain": config.sip_domain,
+                "voipDeviceToken": config.device_token,
+                "pushDeviceToken": config.device_token,
+                "remoteSrv": 1,
+                "appName": config.app_name,
+                "osType": config.os_type,
+                "lang": config.app_lang,
+            },
+        )
+        if xip_status != 200:
+            _LOGGER.warning(
+                "xipregister returned %s for sip user %s; continuing with SIP flow",
+                xip_status,
+                config.sip_user,
+            )
+        return {
+            "xipregister": xip_body,
+            "xipregister_status": xip_status,
+        }
+
+    async def async_resolve_bpt_door_config(
+        self,
+        device_id: int | str,
+        options: Mapping[str, Any],
+    ) -> BptDoorConfig:
+        config = BptDoorConfig.from_mapping(options)
+        if config is not None:
+            return config
+
+        if not BptDoorConfig.has_credentials(options):
+            raise CameApiError(
+                f"Missing BPT credentials. Set either {CONF_BPT_SIP_PASSWORD} "
+                f"or {CONF_BPT_SIP_HA1}."
+            )
+
+        device_token = str(options.get(CONF_BPT_DEVICE_TOKEN, "")).strip()
+        preferred_sip_user = str(options.get(CONF_BPT_SIP_USER, "")).strip()
+        preferred_subject_label = str(options.get(CONF_BPT_SUBJECT_LABEL, "")).strip()
+        preferred_src_addr = str(options.get(CONF_BPT_SRC_ADDR, "")).strip()
+
+        resolved = await self.async_resolve_bpt_target(
+            device_id,
+            options,
+            preferred_sip_user=preferred_sip_user,
+            preferred_subject_label=preferred_subject_label,
+            preferred_src_addr=preferred_src_addr,
+        )
+        config = BptDoorConfig.from_mapping(options, discovery=resolved.discovery)
+        if config is None:
+            raise CameApiError("Incomplete BPT configuration after autodiscovery")
+        return config
+
+    async def async_get_bpt_device_metadata(
+        self,
+        device_id: int | str,
+        options: Mapping[str, Any],
+    ) -> BptDeviceMetadata:
+        preferred_sip_user = str(options.get(CONF_BPT_SIP_USER, "")).strip()
+        preferred_subject_label = str(options.get(CONF_BPT_SUBJECT_LABEL, "")).strip()
+        preferred_src_addr = str(options.get(CONF_BPT_SRC_ADDR, "")).strip()
+        resolved = await self.async_resolve_bpt_target(
+            device_id,
+            options,
+            preferred_sip_user=preferred_sip_user,
+            preferred_subject_label=preferred_subject_label,
+            preferred_src_addr=preferred_src_addr,
+        )
+        return _extract_bpt_device_metadata(resolved.device)
+
+    async def async_get_bpt_setup_preview(
+        self,
+        device_id: int | str,
+        options: Mapping[str, Any],
+    ) -> BptSetupPreview:
+        preferred_sip_user = str(options.get(CONF_BPT_SIP_USER, "")).strip()
+        preferred_subject_label = str(options.get(CONF_BPT_SUBJECT_LABEL, "")).strip()
+        preferred_src_addr = str(options.get(CONF_BPT_SRC_ADDR, "")).strip()
+        manual_device_token = str(options.get(CONF_BPT_DEVICE_TOKEN, "")).strip()
+
+        token_candidates: list[tuple[str, BptSipAccount | None]] = []
+        if manual_device_token:
+            token_candidates.append((manual_device_token, None))
+
+        sip_accounts: list[BptSipAccount] = []
+        last_error: Exception | None = None
+        try:
+            sip_accounts = await self.async_get_sip_accounts()
+        except CameApiError as err:
+            if not manual_device_token:
+                raise
+            last_error = err
+
+        token_candidates.extend((account.device_token, account) for account in sip_accounts)
+
+        seen_tokens: set[str] = set()
+        for candidate_token, sip_account in token_candidates:
+            if not candidate_token or candidate_token in seen_tokens:
+                continue
+            seen_tokens.add(candidate_token)
+
+            try:
+                sites = await self.async_get_sites(candidate_token)
+                for site in sites:
+                    site_id = site.get("Id") or site.get("SiteId")
+                    if site_id is None:
+                        continue
+                    devices = await self.async_get_site_devices(site_id, candidate_token)
+                    device = _find_device_record(devices, device_id)
+                    if device is None:
+                        continue
+
+                    metadata = _extract_bpt_device_metadata(device)
+                    metadata_slots = _extract_bpt_mobile_slots(device)
+                    accounts_for_token = [account for account in sip_accounts if account.device_token == candidate_token]
+
+                    if manual_device_token and candidate_token == manual_device_token and sip_account is None:
+                        valid_slots = metadata_slots
+                        token_source = "manual_override"
+                    else:
+                        valid_slots = []
+                        for account in accounts_for_token:
+                            matched = next(
+                                (
+                                    slot
+                                    for slot in metadata_slots
+                                    if slot.sip_user == account.sip_user or slot.src_addr == account.src_addr
+                                ),
+                                None,
+                            )
+                            valid_slots.append(
+                                matched
+                                or BptMobileSlot(
+                                    sip_user=account.sip_user,
+                                    src_addr=account.src_addr,
+                                    subject_label=account.sip_user,
+                                )
+                            )
+                        token_source = "sipaccounts"
+
+                    selected_slot = _select_bpt_mobile_slot(
+                        valid_slots,
+                        preferred_sip_user=preferred_sip_user,
+                        preferred_subject_label=preferred_subject_label,
+                        preferred_src_addr=preferred_src_addr,
+                        allow_empty=True,
+                    )
+
+                    return BptSetupPreview(
+                        slots=tuple(valid_slots),
+                        selected_slot=selected_slot,
+                        metadata=metadata,
+                        token_source=token_source,
+                    )
+            except CameApiError as err:
+                last_error = err
+
+        if last_error:
+            raise last_error
+        raise CameApiError(f"BPT device {device_id} was not found during setup preview discovery")
+
+    async def async_resolve_bpt_target(
+        self,
+        device_id: int | str,
+        options: Mapping[str, Any],
+        *,
+        preferred_sip_user: str = "",
+        preferred_subject_label: str = "",
+        preferred_src_addr: str = "",
+    ) -> BptResolvedTarget:
+        device_token = str(options.get(CONF_BPT_DEVICE_TOKEN, "")).strip()
+
+        token_candidates: list[tuple[str, BptSipAccount | None]] = []
+        if device_token:
+            token_candidates.append((device_token, None))
+
+        sip_accounts: list[BptSipAccount] = []
+        last_error: Exception | None = None
+        try:
+            sip_accounts = _filter_bpt_sip_accounts(
+                await self.async_get_sip_accounts(),
+                preferred_sip_user=preferred_sip_user,
+                preferred_src_addr=preferred_src_addr,
+            )
+        except CameApiError as err:
+            if not device_token:
+                raise
+            last_error = err
+
+        token_candidates.extend((account.device_token, account) for account in sip_accounts)
+
+        seen_candidates: set[tuple[str, str, str]] = set()
+        for candidate_token, sip_account in token_candidates:
+            candidate_sip_user = preferred_sip_user or (sip_account.sip_user if sip_account else "")
+            candidate_src_addr = preferred_src_addr or (sip_account.src_addr if sip_account else "")
+            candidate_key = (candidate_token, candidate_sip_user, candidate_src_addr)
+            if not candidate_token or candidate_key in seen_candidates:
+                continue
+            seen_candidates.add(candidate_key)
+
+            try:
+                sites = await self.async_get_sites(candidate_token)
+                for site in sites:
+                    site_id = site.get("Id") or site.get("SiteId")
+                    if site_id is None:
+                        continue
+                    devices = await self.async_get_site_devices(site_id, candidate_token)
+                    device = _find_device_record(devices, device_id)
+                    if device is None:
+                        continue
+
+                    if sip_account and sip_account.keycode and not device.get("Keycode"):
+                        device = dict(device)
+                        device["Keycode"] = sip_account.keycode
+
+                    discovery = _extract_bpt_discovery(
+                        device,
+                        preferred_sip_user=candidate_sip_user,
+                        preferred_subject_label=preferred_subject_label,
+                        preferred_src_addr=candidate_src_addr,
+                    )
+                    discovery = BptDiscovery(
+                        keycode=discovery.keycode,
+                        sip_user=discovery.sip_user,
+                        src_addr=discovery.src_addr,
+                        subject_label=discovery.subject_label,
+                        target_user=discovery.target_user,
+                        panel_addr=discovery.panel_addr,
+                        device_token=candidate_token,
+                    )
+                    return BptResolvedTarget(
+                        device_token=candidate_token,
+                        device=device,
+                        discovery=discovery,
+                        sip_account=sip_account,
+                    )
+            except CameApiError as err:
+                last_error = err
+
+        if last_error:
+            raise last_error
+        raise CameApiError(f"BPT device {device_id} was not found during autodiscovery")
+
+    async def async_get_sip_accounts(self) -> list[BptSipAccount]:
+        status, js = await self._request("GET", f"{API_BASE}/sipaccounts")
+        if status != 200:
+            raise CameApiError(f"sipaccounts discovery failed: {status} {js}")
+        accounts = _extract_bpt_sip_accounts(js)
+        if not accounts:
+            raise CameApiError("No BPT SIP accounts returned during autodiscovery")
+        return accounts
+
+    async def async_get_sites(self, device_token: str) -> list[dict[str, Any]]:
+        status, js = await self._request(
+            "GET",
+            f"{API_BASE}/evo/v1/sites",
+            params={"dt": device_token},
+        )
+        if status != 200:
+            raise CameApiError(f"site discovery failed: {status} {js}")
+        sites = _coerce_list(js)
+        if not sites:
+            raise CameApiError("No sites returned during BPT autodiscovery")
+        return sites
+
+    async def async_get_site_devices(self, site_id: int | str, device_token: str) -> list[dict[str, Any]]:
+        status, js = await self._request(
+            "GET",
+            f"{API_BASE}/evo/v1/sites/{site_id}/devices",
+            params={"dt": device_token},
+        )
+        if status != 200:
+            raise CameApiError(f"device discovery failed for site {site_id}: {status} {js}")
+        return _coerce_list(js)
+
+    def _send_bpt_xml_command(
+        self,
+        config: BptDoorConfig,
+        body: str,
+        subject: str | None,
+    ) -> dict[str, Any]:
+        auth_password = config.auth_password
+        ha1_override = config.sip_ha1
+        sock = self._tls_connect(config)
+        try:
+            local_ip, local_port = sock.getsockname()[:2]
+            register_call_id = f"{uuid.uuid4().hex}@{local_ip}"
+            register_tag = uuid.uuid4().hex[:8]
+
+            first_register = self._build_register_request(
+                config,
+                local_ip=local_ip,
+                local_port=local_port,
+                call_id=register_call_id,
+                tag=register_tag,
+                branch=f"z9hG4bK{uuid.uuid4().hex[:8]}",
+                cseq=1,
+            )
+            sock.sendall(first_register)
+            register_response = self._recv_sip_response(sock)
+            register_status = self._response_status_line(register_response)
+
+            if "200" not in register_status:
+                register_response = self._retry_authenticated_request(
+                    sock=sock,
+                    response=register_response,
+                    method="REGISTER",
+                    uri=f"sip:{config.sip_domain}",
+                    sip_user=config.sip_user,
+                    auth_password=auth_password,
+                    ha1_override=ha1_override,
+                    request_builder=lambda auth_header, cseq: self._build_register_request(
+                        config,
+                        local_ip=local_ip,
+                        local_port=local_port,
+                        call_id=register_call_id,
+                        tag=register_tag,
+                        branch=f"z9hG4bK{uuid.uuid4().hex[:8]}",
+                        cseq=cseq,
+                        auth_header=auth_header,
+                    ),
+                )
+                register_status = self._response_status_line(register_response)
+
+            if "200" not in register_status:
+                raise CameAuthError(f"SIP REGISTER failed: {register_status}")
+
+            message_call_id = f"{uuid.uuid4().hex}@{local_ip}"
+            message_tag = uuid.uuid4().hex[:8]
+            first_message = self._build_message_request(
+                config,
+                local_ip=local_ip,
+                local_port=local_port,
+                call_id=message_call_id,
+                tag=message_tag,
+                branch=f"z9hG4bK{uuid.uuid4().hex[:8]}",
+                cseq=1,
+                subject=subject,
+                body=body,
+            )
+            sock.sendall(first_message)
+            message_response = self._recv_sip_response(sock)
+            message_status = self._response_status_line(message_response)
+
+            if "200" not in message_status and "202" not in message_status:
+                message_response = self._retry_authenticated_request(
+                    sock=sock,
+                    response=message_response,
+                    method="MESSAGE",
+                    uri=f"sip:{config.target_user}@{config.sip_domain}",
+                    sip_user=config.sip_user,
+                    auth_password=auth_password,
+                    ha1_override=ha1_override,
+                    request_builder=lambda auth_header, cseq: self._build_message_request(
+                        config,
+                        local_ip=local_ip,
+                        local_port=local_port,
+                        call_id=message_call_id,
+                        tag=message_tag,
+                        branch=f"z9hG4bK{uuid.uuid4().hex[:8]}",
+                        cseq=cseq,
+                        subject=subject,
+                        body=body,
+                        auth_header=auth_header,
+                    ),
+                )
+                message_status = self._response_status_line(message_response)
+
+            if "200" not in message_status and "202" not in message_status:
+                raise CameApiError(f"SIP MESSAGE failed: {message_status}")
+
+            return {
+                "register_status": register_status,
+                "message_status": message_status,
+                "subject": subject,
+                "body": body,
+            }
+        finally:
+            sock.close()
+
+    @staticmethod
+    def _tls_connect(config: BptDoorConfig) -> ssl.SSLSocket:
+        def _build_context(legacy_compat: bool = False) -> ssl.SSLContext:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            if legacy_compat:
+                with contextlib.suppress(ssl.SSLError, ValueError):
+                    ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+                if hasattr(ssl, "TLSVersion"):
+                    with contextlib.suppress(ValueError):
+                        ctx.minimum_version = ssl.TLSVersion.TLSv1
+            return ctx
+
+        raw = socket.create_connection((config.proxy_host, config.proxy_port), timeout=10)
+        try:
+            return _build_context().wrap_socket(raw, server_hostname=config.proxy_host)
+        except ssl.SSLError as err:
+            raw.close()
+            _LOGGER.warning(
+                "Default SIP TLS handshake failed for %s:%s (%s); retrying with legacy-compatible TLS settings",
+                config.proxy_host,
+                config.proxy_port,
+                err,
+            )
+            raw = socket.create_connection((config.proxy_host, config.proxy_port), timeout=10)
+            return _build_context(legacy_compat=True).wrap_socket(raw, server_hostname=config.proxy_host)
+
+    @staticmethod
+    def _recv_sip_response(sock: ssl.SSLSocket) -> str:
+        data = b""
+        sock.settimeout(5)
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+                decoded = data.decode(errors="replace")
+                if "\r\n\r\n" not in decoded:
+                    continue
+                match = re.search(r"Content-Length:\s*(\d+)", decoded, re.I)
+                content_len = int(match.group(1)) if match else 0
+                header_end = decoded.index("\r\n\r\n") + 4
+                if len(decoded) - header_end >= content_len:
+                    break
+        except socket.timeout:
+            pass
+        return data.decode(errors="replace")
+
+    @staticmethod
+    def _response_status_line(response: str) -> str:
+        return response.split("\r\n", 1)[0] if response else "No response"
+
+    def _retry_authenticated_request(
+        self,
+        *,
+        sock: ssl.SSLSocket,
+        response: str,
+        method: str,
+        uri: str,
+        sip_user: str,
+        auth_password: str | None,
+        ha1_override: str | None,
+        request_builder: Callable[[str, int], bytes],
+    ) -> str:
+        status_line = self._response_status_line(response)
+        if "401" not in status_line and "407" not in status_line:
+            return response
+
+        challenge_header = ""
+        for line in response.split("\r\n"):
+            if line.lower().startswith("www-authenticate:") or line.lower().startswith("proxy-authenticate:"):
+                challenge_header = line
+                break
+        if not challenge_header:
+            return response
+
+        challenge = _parse_digest_challenge(challenge_header)
+        method_auth = "Authorization" if "401" in status_line else "Proxy-Authorization"
+        auth_header = _build_digest_auth_header(
+            method_auth,
+            challenge,
+            method,
+            uri,
+            sip_user,
+            auth_password,
+            ha1_override=ha1_override,
+        )
+        sock.sendall(request_builder(auth_header, 2))
+        return self._recv_sip_response(sock)
+
+    @staticmethod
+    def _build_register_request(
+        config: BptDoorConfig,
+        *,
+        local_ip: str,
+        local_port: int,
+        call_id: str,
+        tag: str,
+        branch: str,
+        cseq: int,
+        auth_header: str = "",
+    ) -> bytes:
+        contact = f"sip:{config.sip_user}@{local_ip}:{local_port};transport=tls"
+        lines = [
+            f"REGISTER sip:{config.sip_domain} SIP/2.0",
+            f"Via: SIP/2.0/TLS {local_ip}:{local_port};branch={branch};rport",
+            "Max-Forwards: 70",
+            f"To: <sip:{config.sip_user}@{config.sip_domain}>",
+            f"From: <sip:{config.sip_user}@{config.sip_domain}>;tag={tag}",
+            f"Call-ID: {call_id}",
+            f"CSeq: {cseq} REGISTER",
+            f"Contact: <{contact}>",
+            "User-Agent: came-connect-ha/1.3.0",
+            "Expires: 300",
+            "Content-Length: 0",
+        ]
+        if auth_header:
+            lines.insert(-1, auth_header)
+        return ("\r\n".join(lines) + "\r\n\r\n").encode()
+
+    @staticmethod
+    def _build_message_request(
+        config: BptDoorConfig,
+        *,
+        local_ip: str,
+        local_port: int,
+        call_id: str,
+        tag: str,
+        branch: str,
+        cseq: int,
+        subject: str | None,
+        body: str,
+        auth_header: str = "",
+    ) -> bytes:
+        body_bytes = body.encode()
+        to_uri = f"sip:{config.target_user}@{config.sip_domain}"
+        lines = [
+            f"MESSAGE {to_uri} SIP/2.0",
+            f"Via: SIP/2.0/TLS {local_ip}:{local_port};branch={branch};rport",
+            "Max-Forwards: 70",
+            f"To: <{to_uri}>",
+            f"From: <sip:{config.sip_user}@{config.sip_domain}>;tag={tag}",
+            f"Call-ID: {call_id}",
+            f"CSeq: {cseq} MESSAGE",
+            "Content-Type: text/xml",
+            "User-Agent: came-connect-ha/1.3.0",
+            f"Content-Length: {len(body_bytes)}",
+        ]
+        if subject:
+            lines.insert(-2, f"Subject: {subject}")
+        if auth_header:
+            lines.insert(-1, auth_header)
+        lines.append("")
+        lines.append(body)
+        return ("\r\n".join(lines) + "\r\n").encode()
 
 
 

--- a/custom_components/came_connect/button.py
+++ b/custom_components/came_connect/button.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.util import dt as dt_util
+
+from .api import BptAuxFeature, BptDeviceMetadata, BptDoorConfig, CameConnectClient
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _build_bpt_device_info(device_id: str, metadata: BptDeviceMetadata | None) -> DeviceInfo:
+    bpt_device_id = f"{device_id}_bpt"
+    return DeviceInfo(
+        identifiers={(DOMAIN, bpt_device_id)},
+        via_device=(DOMAIN, device_id),
+        name=metadata.device_name if metadata else "BPT/X1 Intercom",
+        manufacturer=metadata.manufacturer if metadata else "CAME",
+        model=metadata.model if metadata else "CAME BPT/X1",
+        configuration_url="https://app.cameconnect.net/",
+    )
+
+
+class _CameBptButtonBase(ButtonEntity):
+    def __init__(
+        self,
+        client: CameConnectClient,
+        device_id: str,
+        options: dict,
+        metadata: BptDeviceMetadata | None = None,
+    ) -> None:
+        self._client = client
+        self._device_id = str(device_id)
+        self._bpt_device_id = f"{self._device_id}_bpt"
+        self._options = options
+        self._config: BptDoorConfig | None = None
+        self._metadata = metadata
+        self._attr_device_info = _build_bpt_device_info(self._device_id, metadata)
+        self._last_run: str | None = None
+        self._last_xipregister_status: str | None = None
+        self._last_register_status: str | None = None
+        self._last_message_status: str | None = None
+        self._last_error: str | None = None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        return {
+            "last_run": self._last_run,
+            "last_xipregister_status": self._last_xipregister_status,
+            "last_register_status": self._last_register_status,
+            "last_message_status": self._last_message_status,
+            "last_error": self._last_error,
+            "sip_user": self._config.sip_user if self._config else None,
+            "src_addr": self._config.src_addr if self._config else None,
+            "target_user": self._config.target_user if self._config else None,
+            "panel_addr": self._config.panel_addr if self._config else None,
+            "subject_label": self._config.subject_label if self._config else None,
+            "bpt_device_name": self._metadata.device_name if self._metadata else None,
+            "bpt_unit_name": self._metadata.unit_name if self._metadata else None,
+            "bpt_entry_panel_name": self._metadata.entry_panel_name if self._metadata else None,
+            "bpt_open_door_label": self._metadata.open_door_label if self._metadata else None,
+        }
+
+    async def _resolve_config(self) -> BptDoorConfig:
+        self._config = await self._client.async_resolve_bpt_door_config(self._device_id, self._options)
+        return self._config
+
+    def _record_success(self, result: dict[str, object]) -> None:
+        self._last_register_status = str(result.get("register_status"))
+        self._last_message_status = str(result.get("message_status"))
+        self._last_xipregister_status = str(result.get("xipregister_status"))
+        self._last_error = None
+        self.async_write_ha_state()
+
+
+class CameBptDoorButton(_CameBptButtonBase):
+    def __init__(
+        self,
+        client: CameConnectClient,
+        device_id: str,
+        options: dict,
+        metadata: BptDeviceMetadata | None = None,
+    ) -> None:
+        super().__init__(client, device_id, options, metadata)
+        self._attr_name = metadata.open_door_label if metadata else "Open Door"
+        self._attr_unique_id = f"came_bpt_open_door_{self._bpt_device_id}"
+        self._attr_icon = "mdi:door-open"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        attrs = super().extra_state_attributes
+        attrs["bpt_aux_count"] = len(self._metadata.aux_features) if self._metadata else 0
+        attrs["bpt_aux_features"] = (
+            [
+                {
+                    "aux_code": feature.aux_code,
+                    "feature_id": feature.feature_id,
+                    "name": feature.name,
+                    "label": feature.label,
+                    "icon": feature.icon,
+                }
+                for feature in self._metadata.aux_features
+            ]
+            if self._metadata
+            else []
+        )
+        return attrs
+
+    async def async_press(self) -> None:
+        self._last_run = dt_util.utcnow().isoformat()
+        try:
+            config = await self._resolve_config()
+            result = await self._client.async_open_bpt_door(config)
+        except Exception as err:
+            self._last_error = str(err)
+            self.async_write_ha_state()
+            raise HomeAssistantError(f"Open door failed: {err}") from err
+
+        self._record_success(result)
+        _LOGGER.debug(
+            "BPT door-open succeeded for %s with register=%s message=%s",
+            self._device_id,
+            self._last_register_status,
+            self._last_message_status,
+        )
+
+
+class CameBptAuxButton(_CameBptButtonBase):
+    def __init__(
+        self,
+        client: CameConnectClient,
+        device_id: str,
+        options: dict,
+        feature: BptAuxFeature,
+        metadata: BptDeviceMetadata | None = None,
+    ) -> None:
+        super().__init__(client, device_id, options, metadata)
+        self._feature = feature
+        self._attr_name = feature.label
+        self._attr_unique_id = f"came_bpt_aux_{feature.feature_id}_{self._bpt_device_id}"
+        self._attr_icon = "mdi:toggle-switch-variant"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        attrs = super().extra_state_attributes
+        attrs.update(
+            {
+                "bpt_aux_code": self._feature.aux_code,
+                "bpt_aux_feature_id": self._feature.feature_id,
+                "bpt_aux_name": self._feature.name,
+                "bpt_aux_label": self._feature.label,
+                "bpt_aux_icon": self._feature.icon,
+            }
+        )
+        return attrs
+
+    async def async_press(self) -> None:
+        self._last_run = dt_util.utcnow().isoformat()
+        try:
+            config = await self._resolve_config()
+            result = await self._client.async_open_bpt_aux(config, self._feature.aux_code)
+        except Exception as err:
+            self._last_error = str(err)
+            self.async_write_ha_state()
+            raise HomeAssistantError(f"{self._feature.label} failed: {err}") from err
+
+        self._record_success(result)
+        _LOGGER.debug(
+            "BPT AUX %s succeeded for %s with register=%s message=%s",
+            self._feature.aux_code,
+            self._device_id,
+            self._last_register_status,
+            self._last_message_status,
+        )
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
+    if not BptDoorConfig.has_credentials(entry.options):
+        return
+
+    data = hass.data[DOMAIN][entry.entry_id]
+    client: CameConnectClient = data["client"]
+    device_id = data["device_id"]
+    metadata = None
+    try:
+        metadata = await client.async_get_bpt_device_metadata(device_id, dict(entry.options))
+    except Exception:
+        _LOGGER.debug("BPT metadata lookup failed during setup; using fallback device labels", exc_info=True)
+
+    entities: list[ButtonEntity] = [CameBptDoorButton(client, device_id, dict(entry.options), metadata)]
+    if metadata:
+        entities.extend(
+            CameBptAuxButton(client, device_id, dict(entry.options), feature, metadata)
+            for feature in metadata.aux_features
+        )
+
+    async_add_entities(entities)

--- a/custom_components/came_connect/config_flow.py
+++ b/custom_components/came_connect/config_flow.py
@@ -2,29 +2,57 @@ from __future__ import annotations
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
-from homeassistant.core import callback
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import BptSetupPreview, CameApiError, CameAuthError, CameConnectClient
 from .const import (
+    CONF_BPT_DEVICE_TOKEN,
+    CONF_BPT_KEYCODE,
+    CONF_BPT_PANEL_ADDR,
+    CONF_BPT_SIP_HA1,
+    CONF_BPT_SIP_PASSWORD,
+    CONF_BPT_SIP_USER,
+    CONF_BPT_SRC_ADDR,
+    CONF_BPT_SUBJECT_LABEL,
+    CONF_BPT_TARGET_USER,
+    CONF_CLIENT_ID,
+    CONF_CLIENT_SECRET,
+    CONF_DEVICE_ID,
+    CONF_PASSWORD,
+    CONF_REDIRECT_URI,
+    CONF_USERNAME,
+    CONF_WEBSOCKET_URL,
+    DEFAULT_REDIRECT_URI,
+    DEFAULT_WEBSOCKET_URL,
     DOMAIN,
-    # Setup fields
-    CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_USERNAME, CONF_PASSWORD, CONF_DEVICE_ID,
-    # Options we still expose
-    CONF_REDIRECT_URI, DEFAULT_REDIRECT_URI,
-    # New WebSocket options
-    CONF_WEBSOCKET_URL, DEFAULT_WEBSOCKET_URL,
 )
 
-# Initial setup schema: essentials only
-STEP_USER_DATA_SCHEMA = vol.Schema({
-    vol.Required(CONF_CLIENT_ID): str,
-    vol.Required(CONF_CLIENT_SECRET): str,
-    vol.Required(CONF_USERNAME): str,
-    vol.Required(CONF_PASSWORD): str,
-    vol.Required(CONF_DEVICE_ID): str,
-})
+BPT_OPTION_KEYS = (
+    CONF_BPT_KEYCODE,
+    CONF_BPT_SIP_USER,
+    CONF_BPT_SIP_PASSWORD,
+    CONF_BPT_SIP_HA1,
+    CONF_BPT_SRC_ADDR,
+    CONF_BPT_TARGET_USER,
+    CONF_BPT_PANEL_ADDR,
+    CONF_BPT_SUBJECT_LABEL,
+    CONF_BPT_DEVICE_TOKEN,
+)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CLIENT_ID): str,
+        vol.Required(CONF_CLIENT_SECRET): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_DEVICE_ID): str,
+    }
+)
+
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
@@ -50,32 +78,288 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class CameConnectOptionsFlow(config_entries.OptionsFlow):
+    def _clean(self, user_input: dict, key: str) -> str:
+        value = user_input.get(key, "")
+        return value.strip() if isinstance(value, str) else ""
 
-    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
-        if user_input is not None:
-            return self.async_create_entry(
-                data={
-                    CONF_REDIRECT_URI: user_input[CONF_REDIRECT_URI].strip(),
-                    CONF_WEBSOCKET_URL: user_input[CONF_WEBSOCKET_URL].strip(),
-                }
+    def _current_options(self) -> dict[str, str]:
+        entry = self.config_entry
+        current_options = {
+            CONF_REDIRECT_URI: (
+                entry.options.get(CONF_REDIRECT_URI)
+                or entry.data.get(CONF_REDIRECT_URI)
+                or DEFAULT_REDIRECT_URI
+            ),
+            CONF_WEBSOCKET_URL: entry.options.get(CONF_WEBSOCKET_URL, DEFAULT_WEBSOCKET_URL),
+        }
+        for key in BPT_OPTION_KEYS:
+            current_options[key] = entry.options.get(key, "")
+        return current_options
+
+    def _has_bpt_options(self) -> bool:
+        current = self._current_options()
+        return any(current.get(key, "") for key in BPT_OPTION_KEYS)
+
+    def _build_options(
+        self,
+        *,
+        updates: dict[str, str] | None = None,
+        clear_bpt: bool = False,
+    ) -> dict[str, str]:
+        options = self._current_options()
+        if updates:
+            options.update(updates)
+        if clear_bpt:
+            for key in BPT_OPTION_KEYS:
+                options[key] = ""
+        return options
+
+    @staticmethod
+    def _text_selector() -> selector.TextSelector:
+        return selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+        )
+
+    @staticmethod
+    def _password_selector() -> selector.TextSelector:
+        return selector.TextSelector(
+            selector.TextSelectorConfig(
+                type=selector.TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        )
+
+    def _make_client(self, options: dict[str, str]) -> CameConnectClient:
+        entry = self.config_entry
+        session = async_get_clientsession(self.hass)
+        redirect_uri = (options.get(CONF_REDIRECT_URI) or DEFAULT_REDIRECT_URI).strip()
+        return CameConnectClient(
+            session,
+            entry.data[CONF_CLIENT_ID],
+            entry.data[CONF_CLIENT_SECRET],
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASSWORD],
+            redirect_uri,
+        )
+
+    async def _async_get_bpt_preview(
+        self,
+        options: dict[str, str],
+    ) -> tuple[BptSetupPreview | None, str | None]:
+        try:
+            preview = await self._make_client(options).async_get_bpt_setup_preview(
+                self.config_entry.data[CONF_DEVICE_ID],
+                options,
+            )
+            return preview, None
+        except (CameApiError, CameAuthError) as err:
+            return None, str(err)
+        except Exception as err:
+            return None, f"Live BPT discovery is unavailable right now: {err}"
+
+    @staticmethod
+    def _slot_label(slot_sip_user: str, preview: BptSetupPreview | None) -> str:
+        if preview is None:
+            return slot_sip_user
+        matched = next((slot for slot in preview.slots if slot.sip_user == slot_sip_user), None)
+        if matched is None:
+            return slot_sip_user
+        return f"{matched.subject_label} ({matched.sip_user})"
+
+    def _build_bpt_placeholders(
+        self,
+        preview: BptSetupPreview | None,
+        discovery_message: str | None,
+    ) -> dict[str, str]:
+        if preview is None:
+            return {
+                "discovery_status": discovery_message
+                or "Live BPT discovery is unavailable right now. You can still enter the Mobile App slot manually if needed.",
+                "selected_sip_user": "Not resolved yet",
+                "device_name": "Not resolved yet",
+                "entry_panel_name": "Not resolved yet",
+                "open_door_label": "Not resolved yet",
+                "token_source": "Not resolved yet",
+            }
+
+        if preview.selected_slot is not None:
+            selected_sip_user = f"{preview.selected_slot.subject_label} ({preview.selected_slot.sip_user})"
+        elif len(preview.slots) == 1:
+            slot = preview.slots[0]
+            selected_sip_user = f"{slot.subject_label} ({slot.sip_user})"
+        elif preview.slots:
+            selected_sip_user = "Choose a Mobile App slot below"
+        else:
+            selected_sip_user = "Not resolved yet"
+
+        if len(preview.slots) == 1:
+            discovery_status = "One Mobile App slot was detected and will be used automatically."
+        elif len(preview.slots) > 1:
+            discovery_status = f"{len(preview.slots)} Mobile App slots were detected. Choose one below."
+        else:
+            discovery_status = (
+                discovery_message
+                or "BPT metadata was loaded, but no selectable Mobile App slots were resolved."
             )
 
-        entry = self.config_entry
-
-        current_redirect = (
-            entry.options.get(CONF_REDIRECT_URI)
-            or entry.data.get(CONF_REDIRECT_URI)
-            or DEFAULT_REDIRECT_URI
+        token_source = (
+            "Manual device token override"
+            if preview.token_source == "manual_override"
+            else "Detected from /api/sipaccounts"
         )
-        current_ws_url = entry.options.get(CONF_WEBSOCKET_URL, DEFAULT_WEBSOCKET_URL)
 
+        return {
+            "discovery_status": discovery_status,
+            "selected_sip_user": selected_sip_user,
+            "device_name": preview.metadata.device_name,
+            "entry_panel_name": preview.metadata.entry_panel_name,
+            "open_door_label": preview.metadata.open_door_label,
+            "token_source": token_source,
+        }
+
+    def _build_bpt_schema(
+        self,
+        current: dict[str, str],
+        preview: BptSetupPreview | None,
+    ) -> vol.Schema:
+        schema: dict = {
+            vol.Optional(CONF_BPT_SIP_PASSWORD, default=current[CONF_BPT_SIP_PASSWORD]):
+                self._password_selector(),
+        }
+
+        current_sip_user = current[CONF_BPT_SIP_USER]
+        if preview is None or not preview.slots:
+            schema[
+                vol.Optional(CONF_BPT_SIP_USER, default=current_sip_user)
+            ] = self._text_selector()
+            return vol.Schema(schema)
+
+        slot_values = [slot.sip_user for slot in preview.slots]
+        if len(preview.slots) == 1 and not current_sip_user:
+            return vol.Schema(schema)
+
+        if current_sip_user and current_sip_user not in slot_values:
+            schema[
+                vol.Optional(CONF_BPT_SIP_USER, default=current_sip_user)
+            ] = self._text_selector()
+            return vol.Schema(schema)
+
+        select_options = [
+            selector.SelectOptionDict(
+                value=slot.sip_user,
+                label=f"{slot.subject_label} ({slot.sip_user})",
+            )
+            for slot in preview.slots
+        ]
+        default_sip_user = current_sip_user or (
+            preview.selected_slot.sip_user if preview.selected_slot is not None else ""
+        )
+        schema[
+            vol.Optional(CONF_BPT_SIP_USER, default=default_sip_user)
+        ] = selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=select_options,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        )
+        return vol.Schema(schema)
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        menu_options = ["cloud", "bpt", "bpt_advanced"]
+        if self._has_bpt_options():
+            menu_options.append("disable_bpt")
+        return self.async_show_menu(step_id="init", menu_options=menu_options)
+
+    async def async_step_cloud(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            updates = {
+                CONF_REDIRECT_URI: self._clean(user_input, CONF_REDIRECT_URI),
+                CONF_WEBSOCKET_URL: self._clean(user_input, CONF_WEBSOCKET_URL),
+            }
+            return self.async_create_entry(data=self._build_options(updates=updates))
+
+        current = self._current_options()
         return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema({
-                vol.Required(CONF_REDIRECT_URI, default=current_redirect):
-                    selector.TextSelector(),
-
-                vol.Required(CONF_WEBSOCKET_URL, default=current_ws_url):
-                    selector.TextSelector(),
-            }),
+            step_id="cloud",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_REDIRECT_URI, default=current[CONF_REDIRECT_URI]):
+                        self._text_selector(),
+                    vol.Required(CONF_WEBSOCKET_URL, default=current[CONF_WEBSOCKET_URL]):
+                        self._text_selector(),
+                }
+            ),
         )
+
+    async def async_step_bpt(self, user_input: dict | None = None) -> FlowResult:
+        current = self._current_options()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            selected_sip_user = self._clean(user_input, CONF_BPT_SIP_USER)
+            preview_options = self._build_options(
+                updates={CONF_BPT_SIP_USER: selected_sip_user}
+            )
+            preview, _ = await self._async_get_bpt_preview(preview_options)
+
+            if preview is not None and len(preview.slots) == 1 and not selected_sip_user:
+                selected_sip_user = preview.slots[0].sip_user
+
+            if preview is not None and len(preview.slots) > 1 and not selected_sip_user:
+                errors["base"] = "slot_required"
+            else:
+                updates = {
+                    CONF_BPT_SIP_PASSWORD: self._clean(user_input, CONF_BPT_SIP_PASSWORD),
+                    CONF_BPT_SIP_USER: selected_sip_user,
+                }
+                return self.async_create_entry(data=self._build_options(updates=updates))
+
+        preview, discovery_message = await self._async_get_bpt_preview(current)
+        return self.async_show_form(
+            step_id="bpt",
+            data_schema=self._build_bpt_schema(current, preview),
+            errors=errors,
+            description_placeholders=self._build_bpt_placeholders(preview, discovery_message),
+        )
+
+    async def async_step_bpt_advanced(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            updates = {
+                CONF_BPT_SIP_HA1: self._clean(user_input, CONF_BPT_SIP_HA1),
+                CONF_BPT_DEVICE_TOKEN: self._clean(user_input, CONF_BPT_DEVICE_TOKEN),
+                CONF_BPT_KEYCODE: self._clean(user_input, CONF_BPT_KEYCODE),
+                CONF_BPT_SRC_ADDR: self._clean(user_input, CONF_BPT_SRC_ADDR),
+                CONF_BPT_SUBJECT_LABEL: self._clean(user_input, CONF_BPT_SUBJECT_LABEL),
+                CONF_BPT_TARGET_USER: self._clean(user_input, CONF_BPT_TARGET_USER),
+                CONF_BPT_PANEL_ADDR: self._clean(user_input, CONF_BPT_PANEL_ADDR),
+            }
+            return self.async_create_entry(data=self._build_options(updates=updates))
+
+        current = self._current_options()
+        return self.async_show_form(
+            step_id="bpt_advanced",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_BPT_SIP_HA1, default=current[CONF_BPT_SIP_HA1]):
+                        self._password_selector(),
+                    vol.Optional(CONF_BPT_DEVICE_TOKEN, default=current[CONF_BPT_DEVICE_TOKEN]):
+                        self._password_selector(),
+                    vol.Optional(CONF_BPT_KEYCODE, default=current[CONF_BPT_KEYCODE]):
+                        self._text_selector(),
+                    vol.Optional(CONF_BPT_SRC_ADDR, default=current[CONF_BPT_SRC_ADDR]):
+                        self._text_selector(),
+                    vol.Optional(CONF_BPT_SUBJECT_LABEL, default=current[CONF_BPT_SUBJECT_LABEL]):
+                        self._text_selector(),
+                    vol.Optional(CONF_BPT_TARGET_USER, default=current[CONF_BPT_TARGET_USER]):
+                        self._text_selector(),
+                    vol.Optional(CONF_BPT_PANEL_ADDR, default=current[CONF_BPT_PANEL_ADDR]):
+                        self._text_selector(),
+                }
+            ),
+        )
+
+    async def async_step_disable_bpt(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(data=self._build_options(clear_bpt=True))
+
+        return self.async_show_form(step_id="disable_bpt", data_schema=vol.Schema({}))

--- a/custom_components/came_connect/const.py
+++ b/custom_components/came_connect/const.py
@@ -1,5 +1,5 @@
 DOMAIN = "came_connect"
-PLATFORMS = ["cover", "sensor", "binary_sensor"]
+PLATFORMS = ["cover", "sensor", "binary_sensor", "button"]
 
 # REST base
 API_BASE = "https://app.cameconnect.net/api"
@@ -19,6 +19,25 @@ CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_REDIRECT_URI = "redirect_uri"
 CONF_DEVICE_ID = "device_id"
+CONF_BPT_KEYCODE = "bpt_keycode"
+CONF_BPT_SIP_USER = "bpt_sip_user"
+CONF_BPT_SIP_PASSWORD = "bpt_sip_password"
+CONF_BPT_SIP_HA1 = "bpt_sip_ha1"
+CONF_BPT_SRC_ADDR = "bpt_src_addr"
+CONF_BPT_TARGET_USER = "bpt_target_user"
+CONF_BPT_PANEL_ADDR = "bpt_panel_addr"
+CONF_BPT_SUBJECT_LABEL = "bpt_subject_label"
+CONF_BPT_DEVICE_TOKEN = "bpt_device_token"
+
+# BPT SIP defaults
+DEFAULT_BPT_TARGET_USER = "00800000000"
+DEFAULT_BPT_PANEL_ADDR = "00e00000"
+DEFAULT_BPT_APP_NAME = "com.came.myaccess"
+DEFAULT_BPT_OS_TYPE = "android"
+DEFAULT_BPT_LANG = "pt-PT"
+DEFAULT_BPT_SIP_PROXY_HOST = "104.239.174.100"
+DEFAULT_BPT_SIP_PROXY_PORT = 5061
+DEFAULT_BPT_AUTH_PASSWORD_PREFIX = "BptX1pM0b1l3"
 
 # Event / phase codes
 PHASE_OPEN        = 16

--- a/custom_components/came_connect/manifest.json
+++ b/custom_components/came_connect/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "came_connect",
   "name": "CAME Connect",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "config_flow": true,
   "codeowners": ["@sdeagh"],
   "integration_type": "hub",

--- a/custom_components/came_connect/translations/en.json
+++ b/custom_components/came_connect/translations/en.json
@@ -17,13 +17,74 @@
   "options": {
     "step": {
       "init": {
-        "title": "CAME Connect options",
-        "description": "Redirect and polling settings.",
+        "title": "Options",
+        "description": "Choose which settings you want to update.",
+        "menu_options": {
+          "cloud": "Cloud settings",
+          "bpt": "BPT/X1 door button",
+          "bpt_advanced": "Advanced BPT overrides",
+          "disable_bpt": "Disable BPT/X1 door button"
+        },
+        "menu_option_descriptions": {
+          "cloud": "OAuth redirect and realtime connection settings. Most users never need to change these.",
+          "bpt": "Set up the optional BPT/X1 intercom Open Door button.",
+          "bpt_advanced": "Low-level overrides for troubleshooting or known-good protocol values.",
+          "disable_bpt": "Remove the stored BPT/X1 credentials and override values from this integration."
+        }
+      },
+      "cloud": {
+        "title": "Cloud settings",
+        "description": "These values normally stay at their defaults. Change them only if your CAME client uses a different redirect URI or realtime endpoint.",
         "data": {
           "redirect_uri": "Redirect URI",
-          "websocket_url": "WebSocket URL"
+          "websocket_url": "Realtime WebSocket URL"
+        },
+        "data_description": {
+          "redirect_uri": "OAuth redirect URI used for login. Most users should keep the default value.",
+          "websocket_url": "Realtime endpoint used to receive live gate status updates."
         }
+      },
+      "bpt": {
+        "title": "BPT/X1 door button",
+        "description": "Only for BPT/X1 intercom units such as XTS7 indoor monitors. Most users only need the Mobile App SIP password.\n\nDiscovery status: {discovery_status}\nSelected Mobile App slot: {selected_sip_user}\nIntercom: {device_name}\nEntry panel: {entry_panel_name}\nDoor action label: {open_door_label}\nToken source: {token_source}",
+        "data": {
+          "bpt_sip_password": "Mobile App SIP password",
+          "bpt_sip_user": "Mobile App slot / SIP user"
+        },
+        "data_description": {
+          "bpt_sip_password": "Password for the Mobile App SIP account used to open the door.",
+          "bpt_sip_user": "Shown as a dropdown when live discovery can resolve the available Mobile App slots."
+        }
+      },
+      "bpt_advanced": {
+        "title": "Advanced BPT overrides",
+        "description": "Only use these if autodiscovery fails or if you are forcing known-good values from traces.",
+        "data": {
+          "bpt_sip_ha1": "Mobile App SIP HA1 override",
+          "bpt_device_token": "Legacy device token override",
+          "bpt_keycode": "BPT keycode override",
+          "bpt_src_addr": "Source L3 override",
+          "bpt_subject_label": "Subject label override",
+          "bpt_target_user": "Target SIP user override",
+          "bpt_panel_addr": "Panel L3 override"
+        },
+        "data_description": {
+          "bpt_sip_ha1": "Advanced alternative to the Mobile App SIP password.",
+          "bpt_device_token": "Legacy manual token override. Normally auto-discovered from /api/sipaccounts.",
+          "bpt_keycode": "Force a specific BPT keycode only if metadata discovery is wrong.",
+          "bpt_src_addr": "Force a specific mobile-app L3 address.",
+          "bpt_subject_label": "Force the SIP subject label used in the open-door message.",
+          "bpt_target_user": "Force the target SIP user, usually the entry panel.",
+          "bpt_panel_addr": "Force the panel L3 address used in the XML open-door payload."
+        }
+      },
+      "disable_bpt": {
+        "title": "Disable BPT/X1 door button",
+        "description": "This removes the stored BPT/X1 password, SIP user, HA1, and all BPT override values from this integration. Gate control will remain available."
       }
+    },
+    "error": {
+      "slot_required": "Choose a Mobile App slot before saving."
     }
   }
 }

--- a/docs/maintainers/architecture/integration-overview.md
+++ b/docs/maintainers/architecture/integration-overview.md
@@ -1,0 +1,73 @@
+# Integration Overview
+
+This document is a sanitized maintainer overview of the Home Assistant
+integration. It describes the public architecture without including raw traces,
+captured identifiers, or reverse-engineering artifacts.
+
+## Scope
+
+The integration supports two main capabilities:
+
+- CAME gate or automation control through the CAME Connect cloud API
+- Optional BPT/X1 intercom actions, currently exposed as Home Assistant buttons
+
+## Main Runtime Modules
+
+- [api.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/api.py)
+  Central API client and protocol orchestration.
+- [config_flow.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/config_flow.py)
+  Integration setup and options flow.
+- [cover.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/cover.py)
+  Gate cover entity.
+- [button.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/button.py)
+  BPT/X1 door and AUX buttons.
+- [sensor.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/sensor.py)
+  Status sensors.
+- [binary_sensor.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/binary_sensor.py)
+  Connectivity and motion state.
+
+## Gate Control Path
+
+1. The integration authenticates against CAME Connect using OAuth.
+2. It subscribes to realtime updates through the CAME websocket path.
+3. Device state is mapped into Home Assistant entities.
+4. Cover actions call the cloud API and rely on realtime updates to reflect the
+   resulting state.
+
+## BPT/X1 Path
+
+1. BPT setup is optional and configured in the options flow.
+2. The integration resolves the intercom slot and metadata from the authenticated
+   CAME account path.
+3. Button entities are created on a separate BPT/X1 child device.
+4. Button presses send the validated cloud SIP/TLS command flow through
+   [api.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/api.py).
+
+## Device Model
+
+- The main Home Assistant device represents the CAME gate or automation.
+- When BPT/X1 is enabled, a second child device is created for intercom actions.
+- Gate entities stay on the gate device.
+- Door and AUX buttons stay on the BPT/X1 device.
+
+## Test Strategy
+
+The public test suite is intentionally limited to commit-safe tests:
+
+- parsing and discovery tests
+- transport orchestration tests
+- button behavior tests
+- options flow tests
+
+See [tests](/home/d0m/Projects/gtapps/came_connect/tests) for the current suite.
+
+## Local-Only Boundary
+
+The following stay out of the public repo surface:
+
+- raw captures and system logs
+- reverse-engineering probes and temporary tooling
+- AI workflow files and planning state
+- unsanitized protocol notes
+
+Those artifacts live under `.local/` and are ignored by Git.

--- a/docs/maintainers/architecture/integration-overview.md
+++ b/docs/maintainers/architecture/integration-overview.md
@@ -13,17 +13,17 @@ The integration supports two main capabilities:
 
 ## Main Runtime Modules
 
-- [api.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/api.py)
+- [api.py](/custom_components/came_connect/api.py)
   Central API client and protocol orchestration.
-- [config_flow.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/config_flow.py)
+- [config_flow.py](/custom_components/came_connect/config_flow.py)
   Integration setup and options flow.
-- [cover.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/cover.py)
+- [cover.py](/custom_components/came_connect/cover.py)
   Gate cover entity.
-- [button.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/button.py)
+- [button.py](/custom_components/came_connect/button.py)
   BPT/X1 door and AUX buttons.
-- [sensor.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/sensor.py)
+- [sensor.py](/custom_components/came_connect/sensor.py)
   Status sensors.
-- [binary_sensor.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/binary_sensor.py)
+- [binary_sensor.py](/custom_components/came_connect/binary_sensor.py)
   Connectivity and motion state.
 
 ## Gate Control Path
@@ -41,7 +41,7 @@ The integration supports two main capabilities:
    CAME account path.
 3. Button entities are created on a separate BPT/X1 child device.
 4. Button presses send the validated cloud SIP/TLS command flow through
-   [api.py](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect/api.py).
+   [api.py](/custom_components/came_connect/api.py).
 
 ## Device Model
 
@@ -59,7 +59,7 @@ The public test suite is intentionally limited to commit-safe tests:
 - button behavior tests
 - options flow tests
 
-See [tests](/home/d0m/Projects/gtapps/came_connect/tests) for the current suite.
+See [tests](/tests) for the current suite.
 
 ## Local-Only Boundary
 

--- a/docs/maintainers/contributing.md
+++ b/docs/maintainers/contributing.md
@@ -1,0 +1,44 @@
+# Contributing
+
+This repo keeps a strict boundary between public product files and local-only
+research artifacts.
+
+## Public Files
+
+Normal commits should be limited to:
+
+- [custom_components/came_connect](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect)
+- [tests](/home/d0m/Projects/gtapps/came_connect/tests)
+- [README.md](/home/d0m/Projects/gtapps/came_connect/README.md)
+- [CHANGELOG.md](/home/d0m/Projects/gtapps/came_connect/CHANGELOG.md)
+- [docs/user](/home/d0m/Projects/gtapps/came_connect/docs/user)
+- sanitized maintainer docs under [docs/maintainers](/home/d0m/Projects/gtapps/came_connect/docs/maintainers)
+
+## Local-Only Files
+
+Do not commit anything under `.local/`.
+
+That includes:
+
+- raw captures
+- protocol investigation notes
+- reverse-engineering scripts
+- AI workflow files
+- planning or handoff state
+
+## Verification
+
+Before committing, run:
+
+```bash
+python3 -m py_compile custom_components/came_connect/*.py tests/*.py
+python3 -m unittest discover -s tests -p 'test_*.py'
+```
+
+## Review Guidance
+
+- Prefer small product-facing changes over repo-wide cleanup.
+- Keep tests dummy-only; never place real identifiers or credentials in test
+  data.
+- If a maintainer note contains live identifiers, move it to `.local/` first
+  and only add a sanitized derivative back under `docs/maintainers/`.

--- a/docs/maintainers/contributing.md
+++ b/docs/maintainers/contributing.md
@@ -7,12 +7,12 @@ research artifacts.
 
 Normal commits should be limited to:
 
-- [custom_components/came_connect](/home/d0m/Projects/gtapps/came_connect/custom_components/came_connect)
-- [tests](/home/d0m/Projects/gtapps/came_connect/tests)
-- [README.md](/home/d0m/Projects/gtapps/came_connect/README.md)
-- [CHANGELOG.md](/home/d0m/Projects/gtapps/came_connect/CHANGELOG.md)
-- [docs/user](/home/d0m/Projects/gtapps/came_connect/docs/user)
-- sanitized maintainer docs under [docs/maintainers](/home/d0m/Projects/gtapps/came_connect/docs/maintainers)
+- [custom_components/came_connect]custom_components/came_connect)
+- [tests](/tests)
+- [README.md](/README.md)
+- [CHANGELOG.md](/CHANGELOG.md)
+- [docs/user](/docs/user)
+- sanitized maintainer docs under [docs/maintainers](/docs/maintainers)
 
 ## Local-Only Files
 

--- a/docs/maintainers/protocol/README.md
+++ b/docs/maintainers/protocol/README.md
@@ -1,0 +1,6 @@
+# Maintainer Protocol Notes
+
+Sanitized protocol summaries can live here.
+
+Raw protocol notes with live identifiers are kept under `.local/docs/maintainers/protocol/`
+until they are redacted for version control.

--- a/docs/maintainers/tasks/README.md
+++ b/docs/maintainers/tasks/README.md
@@ -1,0 +1,6 @@
+# Maintainer Task Notes
+
+Sanitized maintainer task prompts can live here.
+
+Task notes that still contain live identifiers or raw capture details are kept
+under `.local/docs/maintainers/tasks/` until they are redacted for version control.

--- a/docs/user/bpt-door-setup.md
+++ b/docs/user/bpt-door-setup.md
@@ -1,0 +1,227 @@
+# BPT/X1 Door Setup
+
+This integration treats BPT/X1 door opening as an optional add-on to the
+normal CAME gate integration.
+
+This guide is for BPT/X1 intercom units such as the **XTS7**.
+
+## Recommended Setup
+
+The cleanest approach is to create a **separate `cameconnect.net` account** for
+Home Assistant and tie that account to its own dedicated **Mobile App slot** on
+the intercom.
+
+That gives you:
+
+- a dedicated SIP user for Home Assistant
+- a dedicated Mobile App password for the intercom path
+- less chance of breaking the slot used by your everyday phone
+
+## Which Account Should I Use?
+
+For normal gate control, you can use your usual owner or administrator CAME
+account.
+
+For BPT/X1, the recommended setup is:
+
+- keep your normal account for day-to-day app use
+- create a **separate invited `cameconnect.net` account** for Home Assistant
+- bind that account to its own dedicated **Mobile App slot**
+
+This keeps the intercom integration separate from the slot used by your phone.
+
+## Before You Start
+
+Make sure the normal CAME integration is already working in Home Assistant
+first.
+
+You should already have:
+
+- the integration added successfully
+- valid CAME credentials
+- the correct CAME device visible in Home Assistant
+
+## Step 1: Create a Dedicated CAME Account
+
+Create a separate `cameconnect.net` account that you want to dedicate to the
+X1 path in Home Assistant.
+
+## Step 2: Find the Unit Local IP
+
+If you do not know the local IP of your XTS7:
+
+1. Go to the **XTS7 panel**
+2. Open **Settings**
+3. Open **Advanced**
+4. Open **Network**
+5. Note the unit IP address
+
+## Step 3: Configure the Mobile App Slot on the Unit
+
+Open the unit web interface in a browser:
+
+```text
+http://<your-unit-ip>
+```
+
+Then:
+
+1. Select **Installer**
+2. Enter the installer password
+   - on **XTS7**, the default is typically `112233`
+   - on other units, use your actual installer password
+3. Open **Credentials**
+4. Choose the **Mobile App** slot you want Home Assistant to use
+5. Set a password for that slot
+6. Note the slot's **SIP ID / SIP user**, for example `00700100001`
+
+You will need:
+
+- the **Mobile App SIP password**
+- optionally the **Mobile App SIP user**
+
+Safety note:
+
+- changing the password of a Mobile App slot can affect any phone or integration
+  already using that same slot
+- this is why a dedicated slot for Home Assistant is strongly recommended
+
+## Step 4: Invite the Dedicated Account
+
+Using the **Came Access** app on Android or iPhone, sign in with the
+administrator or owner account that already manages the installation.
+
+Then go to:
+
+1. **Profile**
+2. **Installations** or **Systems**
+3. Select your system
+4. Select the **Video Entry unit** you want to control
+5. Edit the **Mobile App** slot you prepared for Home Assistant
+6. Send the invite to the new dedicated `cameconnect.net` account
+
+Make sure you keep track of the **Mobile App SIP user** for that slot.
+
+## Step 5: Accept the Invite
+
+Sign in to the **Came Access** mobile app with the **new dedicated account**
+and accept the invitation.
+
+This step ensures the new account is actually linked to the installation and
+the selected video entry unit.
+
+## Step 6: Configure Home Assistant
+
+Open the Home Assistant integration options:
+
+1. **Settings -> Devices & Services**
+2. Open **CAME Connect**
+3. Open **Options**
+4. Open **BPT/X1 door button**
+
+Important:
+
+- the integration entry that should control the BPT/X1 device must use the
+  CAME account that was invited to that Mobile App slot
+- if you created a dedicated `cameconnect.net` account for Home Assistant, use
+  that account's CAME username and password in the integration
+
+In normal setups, you usually only need:
+
+- `Mobile App SIP password`
+- optionally `Mobile App slot / SIP user`
+
+Use `Mobile App slot / SIP user` when:
+
+- you want to force the exact slot you prepared
+- the unit has multiple enabled `Mobile App` slots
+- the options flow asks you to choose between multiple discovered slots
+
+## What The Integration Auto-Discovers
+
+When you press the BPT button, the integration resolves the remaining details
+from the authenticated CAME metadata path.
+
+That normally means you do **not** need to fill:
+
+- `BPT device token`
+- `BPT keycode override`
+- `BPT source L3 override`
+- `BPT subject label override`
+- `BPT target SIP user override`
+- `BPT panel L3 override`
+
+Leave those blank unless you are troubleshooting or forcing known-good values.
+
+## Expected Result
+
+When setup succeeds, Home Assistant should:
+
+1. resolve the intercom and entry-panel metadata
+2. keep the normal gate entities on the main **CAME Connect** device
+3. create a separate **BPT/X1** child device
+4. expose **Open Door**
+5. expose discovered **AUX** buttons when the unit provides them
+
+When live discovery is available, the options flow should also show:
+
+- the selected Mobile App slot
+- the intercom name
+- the entry panel name
+- the door action label
+
+## What Should Appear After Setup?
+
+In Home Assistant you should normally see:
+
+- one main **CAME Connect** device for gate control
+- one **BPT/X1** child device for intercom actions
+- `Open Door` on the BPT/X1 device
+- one or more discovered `AUX` buttons when the unit exposes AUX functions
+
+## Automation Example
+
+The BPT/X1 actions use the normal Home Assistant `button.press` service.
+
+Example:
+
+```yaml
+service: button.press
+target:
+  entity_id: button.open_door
+```
+
+Example AUX button:
+
+```yaml
+service: button.press
+target:
+  entity_id: button.aux_1
+```
+
+## Advanced Overrides
+
+The options flow also includes:
+
+- `Advanced BPT overrides`
+
+These fields are troubleshooting-only. Leave them blank unless autodiscovery
+fails or you are forcing a known-good value from prior testing.
+
+## Troubleshooting
+
+### BPT/X1 device or buttons do not appear
+
+- confirm the invited account accepted the invite in the **Came Access** app
+- confirm the integration is using that same invited account
+- verify the **Mobile App SIP password**
+- if multiple Mobile App slots exist, set **Mobile App slot / SIP user**
+  explicitly
+
+### Gate works but Open Door does not
+
+- recheck the Mobile App slot password in the unit web interface
+- confirm you edited the correct Mobile App slot
+- confirm the SIP user you noted matches the slot assigned to the invited
+  account
+- leave advanced overrides blank unless you are troubleshooting

--- a/tests/_support.py
+++ b/tests/_support.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def ensure_custom_component_packages() -> None:
+    custom_components_pkg = types.ModuleType("custom_components")
+    custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
+    sys.modules.setdefault("custom_components", custom_components_pkg)
+
+    came_connect_pkg = types.ModuleType("custom_components.came_connect")
+    came_connect_pkg.__path__ = [str(ROOT / "custom_components" / "came_connect")]
+    sys.modules.setdefault("custom_components.came_connect", came_connect_pkg)
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def install_homeassistant_stubs() -> None:
+    if "homeassistant" in sys.modules:
+        return
+
+    homeassistant = types.ModuleType("homeassistant")
+    sys.modules["homeassistant"] = homeassistant
+
+    components = types.ModuleType("homeassistant.components")
+    sys.modules["homeassistant.components"] = components
+
+    button_mod = types.ModuleType("homeassistant.components.button")
+
+    class ButtonEntity:
+        @property
+        def name(self):
+            return getattr(self, "_attr_name", None)
+
+        def async_write_ha_state(self) -> None:
+            self._ha_state_written = True
+
+    button_mod.ButtonEntity = ButtonEntity
+    sys.modules["homeassistant.components.button"] = button_mod
+
+    config_entries_mod = types.ModuleType("homeassistant.config_entries")
+
+    class ConfigEntry:
+        def __init__(self, *, data=None, options=None, entry_id: str = "entry-id"):
+            self.data = data or {}
+            self.options = options or {}
+            self.entry_id = entry_id
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            return super().__init_subclass__()
+
+        def async_show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+            return {
+                "type": "form",
+                "step_id": step_id,
+                "data_schema": data_schema,
+                "errors": errors or {},
+                "description_placeholders": description_placeholders,
+            }
+
+        def async_create_entry(self, *, title, data):
+            return {"type": "create_entry", "title": title, "data": data}
+
+    class OptionsFlow:
+        config_entry: ConfigEntry
+
+        def async_show_form(self, *, step_id, data_schema=None, errors=None, description_placeholders=None):
+            return {
+                "type": "form",
+                "step_id": step_id,
+                "data_schema": data_schema,
+                "errors": errors or {},
+                "description_placeholders": description_placeholders,
+            }
+
+        def async_create_entry(self, *, data):
+            return {"type": "create_entry", "data": data}
+
+        def async_show_menu(self, *, step_id, menu_options):
+            return {"type": "menu", "step_id": step_id, "menu_options": menu_options}
+
+    config_entries_mod.ConfigEntry = ConfigEntry
+    config_entries_mod.ConfigFlow = ConfigFlow
+    config_entries_mod.OptionsFlow = OptionsFlow
+    sys.modules["homeassistant.config_entries"] = config_entries_mod
+
+    core_mod = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:
+        pass
+
+    def callback(func):
+        return func
+
+    core_mod.HomeAssistant = HomeAssistant
+    core_mod.callback = callback
+    sys.modules["homeassistant.core"] = core_mod
+
+    data_entry_flow_mod = types.ModuleType("homeassistant.data_entry_flow")
+    data_entry_flow_mod.FlowResult = dict
+    sys.modules["homeassistant.data_entry_flow"] = data_entry_flow_mod
+
+    exceptions_mod = types.ModuleType("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        pass
+
+    exceptions_mod.HomeAssistantError = HomeAssistantError
+    sys.modules["homeassistant.exceptions"] = exceptions_mod
+
+    helpers_mod = types.ModuleType("homeassistant.helpers")
+    sys.modules["homeassistant.helpers"] = helpers_mod
+
+    entity_mod = types.ModuleType("homeassistant.helpers.entity")
+
+    class DeviceInfo(dict):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.__dict__.update(kwargs)
+
+    entity_mod.DeviceInfo = DeviceInfo
+    sys.modules["homeassistant.helpers.entity"] = entity_mod
+
+    aiohttp_client_mod = types.ModuleType("homeassistant.helpers.aiohttp_client")
+
+    def async_get_clientsession(hass):
+        return object()
+
+    aiohttp_client_mod.async_get_clientsession = async_get_clientsession
+    sys.modules["homeassistant.helpers.aiohttp_client"] = aiohttp_client_mod
+
+    selector_mod = types.ModuleType("homeassistant.helpers.selector")
+
+    class TextSelectorType:
+        TEXT = "text"
+        PASSWORD = "password"
+
+    class TextSelectorConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class TextSelector:
+        def __init__(self, config):
+            self.config = config
+
+    class SelectSelectorMode:
+        DROPDOWN = "dropdown"
+
+    class SelectOptionDict(dict):
+        def __init__(self, *, value, label):
+            super().__init__(value=value, label=label)
+
+    class SelectSelectorConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class SelectSelector:
+        def __init__(self, config):
+            self.config = config
+
+    selector_mod.TextSelectorType = TextSelectorType
+    selector_mod.TextSelectorConfig = TextSelectorConfig
+    selector_mod.TextSelector = TextSelector
+    selector_mod.SelectSelectorMode = SelectSelectorMode
+    selector_mod.SelectOptionDict = SelectOptionDict
+    selector_mod.SelectSelectorConfig = SelectSelectorConfig
+    selector_mod.SelectSelector = SelectSelector
+    sys.modules["homeassistant.helpers.selector"] = selector_mod
+
+    util_mod = types.ModuleType("homeassistant.util")
+    sys.modules["homeassistant.util"] = util_mod
+
+    dt_mod = types.ModuleType("homeassistant.util.dt")
+
+    def utcnow():
+        return dt.datetime.now(dt.timezone.utc)
+
+    dt_mod.utcnow = utcnow
+    sys.modules["homeassistant.util.dt"] = dt_mod
+
+
+def install_voluptuous_stub() -> None:
+    if "voluptuous" in sys.modules:
+        return
+
+    voluptuous = types.ModuleType("voluptuous")
+    sentinel = object()
+
+    class Marker:
+        def __init__(self, schema, default=sentinel, required=False):
+            self.schema = schema
+            self.default = default
+            self.required = required
+
+        def __hash__(self):
+            return hash((self.schema, self.default, self.required))
+
+        def __eq__(self, other):
+            return (
+                isinstance(other, Marker)
+                and self.schema == other.schema
+                and self.default == other.default
+                and self.required == other.required
+            )
+
+    class Schema:
+        def __init__(self, schema):
+            self.schema = schema
+
+        def __call__(self, value):
+            return value
+
+    def Required(schema, default=sentinel):
+        return Marker(schema, default=default, required=True)
+
+    def Optional(schema, default=sentinel):
+        return Marker(schema, default=default, required=False)
+
+    voluptuous.Schema = Schema
+    voluptuous.Required = Required
+    voluptuous.Optional = Optional
+    voluptuous.UNDEFINED = sentinel
+    sys.modules["voluptuous"] = voluptuous

--- a/tests/test_bpt_buttons.py
+++ b/tests/test_bpt_buttons.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import unittest
+
+from _support import ROOT, ensure_custom_component_packages, install_homeassistant_stubs, load_module
+
+ensure_custom_component_packages()
+install_homeassistant_stubs()
+
+const_module = load_module(
+    "custom_components.came_connect.const",
+    ROOT / "custom_components" / "came_connect" / "const.py",
+)
+api_module = load_module(
+    "custom_components.came_connect.api",
+    ROOT / "custom_components" / "came_connect" / "api.py",
+)
+button_module = load_module(
+    "custom_components.came_connect.button",
+    ROOT / "custom_components" / "came_connect" / "button.py",
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import HomeAssistantError
+
+DOMAIN = const_module.DOMAIN
+CONF_BPT_SIP_PASSWORD = const_module.CONF_BPT_SIP_PASSWORD
+
+BptAuxFeature = api_module.BptAuxFeature
+BptDeviceMetadata = api_module.BptDeviceMetadata
+BptDoorConfig = api_module.BptDoorConfig
+CameBptAuxButton = button_module.CameBptAuxButton
+CameBptDoorButton = button_module.CameBptDoorButton
+
+DUMMY_DEVICE_ID = "dummy-device-id-1"
+DUMMY_DEVICE_NAME = "Example Indoor Monitor"
+DUMMY_ENTRY_PANEL_NAME = "Example Entry Panel"
+DUMMY_UNIT_NAME = "Example Unit"
+DUMMY_OPEN_DOOR_LABEL = "Example Open Door"
+DUMMY_AUX_ONE_LABEL = "Demo Aux One"
+DUMMY_KEYCODE = "EXAMPLEKEYCODE01"
+DUMMY_SIP_USER = "dummy_sip_user_2"
+DUMMY_PASSWORD = "dummy-password"
+DUMMY_SRC_ADDR = "dummy-src-2"
+DUMMY_TARGET_USER = "dummy-target-user"
+DUMMY_PANEL_ADDR = "dummy-panel-addr"
+DUMMY_SUBJECT_LABEL = "Demo Mobile Slot 2"
+DUMMY_DEVICE_TOKEN = "dummy-device-token-1"
+
+
+def _metadata() -> BptDeviceMetadata:
+    return BptDeviceMetadata(
+        device_name=DUMMY_DEVICE_NAME,
+        entry_panel_name=DUMMY_ENTRY_PANEL_NAME,
+        unit_name=DUMMY_UNIT_NAME,
+        open_door_label=DUMMY_OPEN_DOOR_LABEL,
+        aux_features=(
+            BptAuxFeature(aux_code=1, feature_id=8, name="Aux 1", label=DUMMY_AUX_ONE_LABEL, icon="light.png"),
+            BptAuxFeature(aux_code=2, feature_id=9, name="Aux 2", label="Aux 2", icon="light.png"),
+        ),
+        model="CAME BPT X1",
+    )
+
+
+def _config() -> BptDoorConfig:
+    return BptDoorConfig(
+        keycode=DUMMY_KEYCODE,
+        sip_user=DUMMY_SIP_USER,
+        sip_password=DUMMY_PASSWORD,
+        src_addr=DUMMY_SRC_ADDR,
+        target_user=DUMMY_TARGET_USER,
+        panel_addr=DUMMY_PANEL_ADDR,
+        subject_label=DUMMY_SUBJECT_LABEL,
+        device_token=DUMMY_DEVICE_TOKEN,
+    )
+
+
+class BptButtonTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_setup_entry_creates_door_and_aux_buttons(self) -> None:
+        metadata = _metadata()
+        client = SimpleNamespace(async_get_bpt_device_metadata=AsyncMock(return_value=metadata))
+        hass = SimpleNamespace(
+            data={
+                DOMAIN: {
+                    "entry-id": {
+                        "client": client,
+                        "device_id": DUMMY_DEVICE_ID,
+                    }
+                }
+            }
+        )
+        entry = ConfigEntry(
+            options={CONF_BPT_SIP_PASSWORD: "pw"},
+            entry_id="entry-id",
+        )
+        added: list = []
+
+        await button_module.async_setup_entry(hass, entry, added.extend)
+
+        self.assertEqual(len(added), 3)
+        self.assertIsInstance(added[0], CameBptDoorButton)
+        self.assertIsInstance(added[1], CameBptAuxButton)
+        self.assertEqual(added[1].name, DUMMY_AUX_ONE_LABEL)
+        self.assertEqual(added[2].name, "Aux 2")
+
+    async def test_async_setup_entry_falls_back_to_only_door_button_on_metadata_error(self) -> None:
+        client = SimpleNamespace(async_get_bpt_device_metadata=AsyncMock(side_effect=RuntimeError("no metadata")))
+        hass = SimpleNamespace(
+            data={
+                DOMAIN: {
+                    "entry-id": {
+                        "client": client,
+                        "device_id": DUMMY_DEVICE_ID,
+                    }
+                }
+            }
+        )
+        entry = ConfigEntry(
+            options={CONF_BPT_SIP_PASSWORD: "pw"},
+            entry_id="entry-id",
+        )
+        added: list = []
+
+        await button_module.async_setup_entry(hass, entry, added.extend)
+
+        self.assertEqual(len(added), 1)
+        self.assertIsInstance(added[0], CameBptDoorButton)
+        self.assertEqual(added[0].name, "Open Door")
+
+    async def test_aux_button_press_calls_client_and_records_status(self) -> None:
+        metadata = _metadata()
+        feature = metadata.aux_features[1]
+        config = _config()
+        client = SimpleNamespace(
+            async_resolve_bpt_door_config=AsyncMock(return_value=config),
+            async_open_bpt_aux=AsyncMock(
+                return_value={
+                    "register_status": "SIP/2.0 200 OK",
+                    "message_status": "SIP/2.0 202 Accepted",
+                    "xipregister_status": 403,
+                }
+            ),
+        )
+        button = CameBptAuxButton(client, DUMMY_DEVICE_ID, {CONF_BPT_SIP_PASSWORD: "pw"}, feature, metadata)
+
+        await button.async_press()
+
+        client.async_open_bpt_aux.assert_awaited_once_with(config, 2)
+        attrs = button.extra_state_attributes
+        self.assertEqual(attrs["last_register_status"], "SIP/2.0 200 OK")
+        self.assertEqual(attrs["last_message_status"], "SIP/2.0 202 Accepted")
+        self.assertEqual(attrs["last_xipregister_status"], "403")
+        self.assertEqual(attrs["bpt_aux_code"], 2)
+        self.assertIsNone(attrs["last_error"])
+
+    async def test_door_button_press_failure_sets_last_error(self) -> None:
+        metadata = _metadata()
+        config = _config()
+        client = SimpleNamespace(
+            async_resolve_bpt_door_config=AsyncMock(return_value=config),
+            async_open_bpt_door=AsyncMock(side_effect=RuntimeError("boom")),
+        )
+        button = CameBptDoorButton(client, DUMMY_DEVICE_ID, {CONF_BPT_SIP_PASSWORD: "pw"}, metadata)
+
+        with self.assertRaises(HomeAssistantError) as ctx:
+            await button.async_press()
+
+        self.assertIn("Open door failed", str(ctx.exception))
+        self.assertEqual(button.extra_state_attributes["last_error"], "boom")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bpt_discovery.py
+++ b/tests/test_bpt_discovery.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest.mock import AsyncMock
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+custom_components_pkg = types.ModuleType("custom_components")
+custom_components_pkg.__path__ = [str(ROOT / "custom_components")]
+sys.modules.setdefault("custom_components", custom_components_pkg)
+
+came_connect_pkg = types.ModuleType("custom_components.came_connect")
+came_connect_pkg.__path__ = [str(ROOT / "custom_components" / "came_connect")]
+sys.modules.setdefault("custom_components.came_connect", came_connect_pkg)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+const_module = _load_module(
+    "custom_components.came_connect.const",
+    ROOT / "custom_components" / "came_connect" / "const.py",
+)
+api_module = _load_module(
+    "custom_components.came_connect.api",
+    ROOT / "custom_components" / "came_connect" / "api.py",
+)
+
+BptDoorConfig = api_module.BptDoorConfig
+BptSipAccount = api_module.BptSipAccount
+CameApiError = api_module.CameApiError
+_extract_bpt_discovery = api_module._extract_bpt_discovery
+_extract_bpt_device_metadata = api_module._extract_bpt_device_metadata
+_extract_bpt_mobile_slots = api_module._extract_bpt_mobile_slots
+_extract_bpt_sip_accounts = api_module._extract_bpt_sip_accounts
+_filter_bpt_sip_accounts = api_module._filter_bpt_sip_accounts
+_find_device_record = api_module._find_device_record
+_build_aux_xml = api_module._build_aux_xml
+
+from custom_components.came_connect.const import (
+    CONF_BPT_SIP_HA1,
+    CONF_BPT_SIP_PASSWORD,
+    CONF_BPT_SIP_USER,
+)
+
+DUMMY_DEVICE_ID = 424242
+DUMMY_SITE_ID = 313131
+DUMMY_DEVICE_NAME = "Example Indoor Monitor"
+DUMMY_UNIT_NAME = "Example Unit"
+DUMMY_ENTRY_PANEL_NAME = "Example Entry Panel"
+DUMMY_OPEN_DOOR_LABEL = "Example Open Door"
+DUMMY_AUX_ONE_LABEL = "Demo Aux One"
+DUMMY_KEYCODE = "EXAMPLEKEYCODE01"
+DUMMY_SECONDARY_KEYCODE = "EXAMPLEKEYCODE99"
+DUMMY_SRC_ADDR_ONE = "dummy-src-1"
+DUMMY_SRC_ADDR_TWO = "dummy-src-2"
+DUMMY_SRC_ADDR_OTHER = "dummy-src-9"
+DUMMY_PANEL_ADDR = "dummy-panel-addr"
+DUMMY_TARGET_USER = "dummy-target-user"
+DUMMY_SIP_USER_ONE = "dummy_sip_user_1"
+DUMMY_SIP_USER_TWO = "dummy_sip_user_2"
+DUMMY_OTHER_SIP_USER = "dummy_sip_user_9"
+DUMMY_DEVICE_TOKEN = "dummy-device-token-1"
+DUMMY_OTHER_DEVICE_TOKEN = "dummy-device-token-2"
+DUMMY_PASSWORD = "dummy-password"
+DUMMY_OTHER_PASSWORD = "other-dummy-password"
+DUMMY_EMAIL = "example@example.test"
+DUMMY_SLOT_ONE_LABEL = "Demo Mobile Slot 1"
+DUMMY_SLOT_TWO_LABEL = "Demo Mobile Slot 2"
+
+
+SAMPLE_DEVICE = {
+    "Id": 144565,
+    "DeviceId": DUMMY_DEVICE_ID,
+    "Name": DUMMY_DEVICE_NAME,
+    "PlantType": "X1",
+    "Keycode": DUMMY_KEYCODE,
+    "Modules": [
+        {
+            "ModuleId": 2,
+            "Name": DUMMY_UNIT_NAME,
+            "AliasName": "",
+            "Features": [
+                {
+                    "Name": DUMMY_SLOT_ONE_LABEL,
+                    "AliasName": "",
+                    "FeatureId": 4,
+                    "Settings": [
+                        {"SettingId": 2, "Value": DUMMY_SRC_ADDR_ONE},
+                        {"SettingId": 1, "Value": DUMMY_SIP_USER_ONE},
+                        {"SettingId": 5, "Value": "true"},
+                    ],
+                },
+                {
+                    "Name": DUMMY_SLOT_TWO_LABEL,
+                    "AliasName": "",
+                    "FeatureId": 4,
+                    "Settings": [
+                        {"SettingId": 2, "Value": DUMMY_SRC_ADDR_TWO},
+                        {"SettingId": 1, "Value": DUMMY_SIP_USER_TWO},
+                        {"SettingId": 5, "Value": "true"},
+                    ],
+                },
+            ],
+        },
+        {
+            "ModuleId": 1,
+            "Name": DUMMY_ENTRY_PANEL_NAME,
+            "AliasName": "",
+            "Settings": [
+                {"SettingId": 4, "Value": DUMMY_PANEL_ADDR},
+                {"SettingId": 3, "Value": DUMMY_TARGET_USER},
+            ],
+            "Features": [
+                {
+                    "Name": DUMMY_OPEN_DOOR_LABEL,
+                    "AliasName": DUMMY_OPEN_DOOR_LABEL,
+                    "FeatureId": 2,
+                },
+                {
+                    "Name": "Aux 1",
+                    "AliasName": DUMMY_AUX_ONE_LABEL,
+                    "FeatureId": 8,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 2",
+                    "AliasName": "",
+                    "FeatureId": 9,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 3",
+                    "AliasName": "",
+                    "FeatureId": 10,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 4",
+                    "AliasName": "",
+                    "FeatureId": 11,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 5",
+                    "AliasName": "",
+                    "FeatureId": 12,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 6",
+                    "AliasName": "",
+                    "FeatureId": 13,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 7",
+                    "AliasName": "",
+                    "FeatureId": 14,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 8",
+                    "AliasName": "",
+                    "FeatureId": 15,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 9",
+                    "AliasName": "",
+                    "FeatureId": 16,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+                {
+                    "Name": "Aux 10",
+                    "AliasName": "",
+                    "FeatureId": 17,
+                    "Settings": [{"SettingId": 6, "Value": "light.png"}],
+                },
+            ],
+        },
+    ],
+}
+
+SAMPLE_SIPACCOUNTS = [
+    {
+        "DeviceToken": DUMMY_DEVICE_TOKEN,
+        "SipUserName": DUMMY_SIP_USER_TWO,
+        "SipPassword": DUMMY_PASSWORD,
+        "BptL3Addr": DUMMY_SRC_ADDR_TWO,
+        "Keycode": DUMMY_KEYCODE,
+        "UserEmail": DUMMY_EMAIL,
+    },
+    {
+        "DeviceToken": DUMMY_OTHER_DEVICE_TOKEN,
+        "SipUserName": DUMMY_OTHER_SIP_USER,
+        "SipPassword": DUMMY_OTHER_PASSWORD,
+        "BptL3Addr": DUMMY_SRC_ADDR_OTHER,
+        "Keycode": DUMMY_SECONDARY_KEYCODE,
+        "UserEmail": DUMMY_EMAIL,
+    },
+    {
+        "DeviceToken": "",
+        "SipUserName": "broken",
+        "BptL3Addr": "dummy-src-broken",
+        "Keycode": "broken",
+    },
+]
+
+
+class BptDiscoveryTests(unittest.TestCase):
+    def test_extract_discovery_uses_selected_sip_user(self) -> None:
+        discovery = _extract_bpt_discovery(SAMPLE_DEVICE, preferred_sip_user=DUMMY_SIP_USER_TWO)
+        self.assertEqual(discovery.keycode, DUMMY_KEYCODE)
+        self.assertEqual(discovery.sip_user, DUMMY_SIP_USER_TWO)
+        self.assertEqual(discovery.src_addr, DUMMY_SRC_ADDR_TWO)
+        self.assertEqual(discovery.subject_label, DUMMY_SLOT_TWO_LABEL)
+        self.assertEqual(discovery.target_user, DUMMY_TARGET_USER)
+        self.assertEqual(discovery.panel_addr, DUMMY_PANEL_ADDR)
+
+    def test_extract_discovery_requires_selection_when_multiple_slots_exist(self) -> None:
+        with self.assertRaises(CameApiError) as ctx:
+            _extract_bpt_discovery(SAMPLE_DEVICE)
+        self.assertIn(CONF_BPT_SIP_USER, str(ctx.exception))
+
+    def test_extract_bpt_device_metadata_uses_device_and_feature_labels(self) -> None:
+        metadata = _extract_bpt_device_metadata(SAMPLE_DEVICE)
+        self.assertEqual(metadata.device_name, DUMMY_DEVICE_NAME)
+        self.assertEqual(metadata.unit_name, DUMMY_UNIT_NAME)
+        self.assertEqual(metadata.entry_panel_name, DUMMY_ENTRY_PANEL_NAME)
+        self.assertEqual(metadata.open_door_label, DUMMY_OPEN_DOOR_LABEL)
+        self.assertEqual(len(metadata.aux_features), 10)
+        self.assertEqual(metadata.aux_features[0].aux_code, 1)
+        self.assertEqual(metadata.aux_features[0].label, DUMMY_AUX_ONE_LABEL)
+        self.assertEqual(metadata.aux_features[0].feature_id, 8)
+        self.assertEqual(metadata.aux_features[1].aux_code, 2)
+        self.assertEqual(metadata.aux_features[-1].name, "Aux 10")
+        self.assertEqual(metadata.aux_features[-1].aux_code, 10)
+        self.assertEqual(metadata.model, "CAME BPT X1")
+
+    def test_extract_bpt_mobile_slots_returns_enabled_slots(self) -> None:
+        slots = _extract_bpt_mobile_slots(SAMPLE_DEVICE)
+        self.assertEqual(len(slots), 2)
+        self.assertEqual(slots[0].sip_user, DUMMY_SIP_USER_ONE)
+        self.assertEqual(slots[1].subject_label, DUMMY_SLOT_TWO_LABEL)
+
+    def test_extract_bpt_device_metadata_keeps_aux_icon_metadata(self) -> None:
+        metadata = _extract_bpt_device_metadata(SAMPLE_DEVICE)
+        self.assertEqual(metadata.aux_features[0].icon, "light.png")
+
+    def test_build_aux_xml_uses_aux_command_and_index(self) -> None:
+        xml = _build_aux_xml(DUMMY_SRC_ADDR_TWO, DUMMY_PANEL_ADDR, 3)
+        self.assertIn("<type>AUX_COMMAND</type>", xml)
+        self.assertIn("<aux_code>3</aux_code>", xml)
+        self.assertIn(f"<src_addr>{DUMMY_SRC_ADDR_TWO}</src_addr>", xml)
+        self.assertIn(f"<dst_addr>{DUMMY_PANEL_ADDR}</dst_addr>", xml)
+
+    def test_find_device_record_matches_device_id(self) -> None:
+        found = _find_device_record([SAMPLE_DEVICE], str(DUMMY_DEVICE_ID))
+        self.assertEqual(found["Keycode"], DUMMY_KEYCODE)
+
+    def test_config_from_mapping_uses_discovered_defaults(self) -> None:
+        discovery = _extract_bpt_discovery(SAMPLE_DEVICE, preferred_sip_user=DUMMY_SIP_USER_TWO)
+        discovery = api_module.BptDiscovery(
+            keycode=discovery.keycode,
+            sip_user=discovery.sip_user,
+            src_addr=discovery.src_addr,
+            subject_label=discovery.subject_label,
+            target_user=discovery.target_user,
+            panel_addr=discovery.panel_addr,
+            device_token=DUMMY_DEVICE_TOKEN,
+        )
+        config = BptDoorConfig.from_mapping(
+            {
+                CONF_BPT_SIP_PASSWORD: DUMMY_PASSWORD,
+            },
+            discovery=discovery,
+        )
+        assert config is not None
+        self.assertEqual(config.sip_domain, f"{DUMMY_KEYCODE}.xip.cameconnect.net")
+        self.assertEqual(config.sip_user, DUMMY_SIP_USER_TWO)
+        self.assertEqual(config.src_addr, DUMMY_SRC_ADDR_TWO)
+        self.assertEqual(config.subject_label, DUMMY_SLOT_TWO_LABEL)
+        self.assertEqual(config.device_token, DUMMY_DEVICE_TOKEN)
+
+    def test_extract_sip_accounts_ignores_incomplete_rows(self) -> None:
+        accounts = _extract_bpt_sip_accounts(SAMPLE_SIPACCOUNTS)
+        self.assertEqual(len(accounts), 2)
+        self.assertEqual(accounts[0].device_token, DUMMY_DEVICE_TOKEN)
+        self.assertEqual(accounts[0].sip_user, DUMMY_SIP_USER_TWO)
+        self.assertEqual(accounts[0].src_addr, DUMMY_SRC_ADDR_TWO)
+
+    def test_filter_sip_accounts_uses_sip_user_preference(self) -> None:
+        accounts = _extract_bpt_sip_accounts(SAMPLE_SIPACCOUNTS)
+        matches = _filter_bpt_sip_accounts(accounts, preferred_sip_user=DUMMY_SIP_USER_TWO)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].device_token, DUMMY_DEVICE_TOKEN)
+
+    def test_has_credentials_accepts_password_or_ha1_without_device_token(self) -> None:
+        self.assertTrue(BptDoorConfig.has_credentials({CONF_BPT_SIP_PASSWORD: "p"}))
+        self.assertTrue(BptDoorConfig.has_credentials({CONF_BPT_SIP_HA1: "h"}))
+        self.assertFalse(BptDoorConfig.has_credentials({}))
+
+
+class BptResolveConfigTests(unittest.IsolatedAsyncioTestCase):
+    async def test_resolve_config_uses_sipaccounts_bootstrap(self) -> None:
+        client = api_module.CameConnectClient(
+            session=None,
+            client_id="client",
+            client_secret="secret",
+            username="user",
+            password="pass",
+            redirect_uri="https://app.cameconnect.net/role",
+        )
+        client.async_get_sip_accounts = AsyncMock(
+            return_value=[
+                BptSipAccount(
+                    device_token=DUMMY_DEVICE_TOKEN,
+                    sip_user=DUMMY_SIP_USER_TWO,
+                    src_addr=DUMMY_SRC_ADDR_TWO,
+                    keycode=DUMMY_KEYCODE,
+                    sip_password=DUMMY_PASSWORD,
+                )
+            ]
+        )
+        client.async_get_sites = AsyncMock(return_value=[{"Id": DUMMY_SITE_ID}])
+        client.async_get_site_devices = AsyncMock(return_value=[SAMPLE_DEVICE])
+
+        config = await client.async_resolve_bpt_door_config(
+            str(DUMMY_DEVICE_ID),
+            {
+                CONF_BPT_SIP_PASSWORD: DUMMY_PASSWORD,
+            },
+        )
+
+        self.assertEqual(config.device_token, DUMMY_DEVICE_TOKEN)
+        self.assertEqual(config.keycode, DUMMY_KEYCODE)
+        self.assertEqual(config.sip_user, DUMMY_SIP_USER_TWO)
+        self.assertEqual(config.src_addr, DUMMY_SRC_ADDR_TWO)
+
+    async def test_setup_preview_returns_dropdown_context_from_sipaccounts(self) -> None:
+        client = api_module.CameConnectClient(
+            session=None,
+            client_id="client",
+            client_secret="secret",
+            username="user",
+            password="pass",
+            redirect_uri="https://app.cameconnect.net/role",
+        )
+        client.async_get_sip_accounts = AsyncMock(
+            return_value=[
+                BptSipAccount(
+                    device_token=DUMMY_DEVICE_TOKEN,
+                    sip_user=DUMMY_SIP_USER_TWO,
+                    src_addr=DUMMY_SRC_ADDR_TWO,
+                    keycode=DUMMY_KEYCODE,
+                    sip_password=DUMMY_PASSWORD,
+                )
+            ]
+        )
+        client.async_get_sites = AsyncMock(return_value=[{"Id": DUMMY_SITE_ID}])
+        client.async_get_site_devices = AsyncMock(return_value=[SAMPLE_DEVICE])
+
+        preview = await client.async_get_bpt_setup_preview(str(DUMMY_DEVICE_ID), {})
+
+        self.assertEqual(preview.token_source, "sipaccounts")
+        self.assertEqual(len(preview.slots), 1)
+        self.assertEqual(preview.selected_slot.sip_user, DUMMY_SIP_USER_TWO)
+        self.assertEqual(preview.metadata.device_name, DUMMY_DEVICE_NAME)
+        self.assertEqual(preview.metadata.entry_panel_name, DUMMY_ENTRY_PANEL_NAME)
+
+    async def test_resolve_config_raises_when_sip_user_is_unknown(self) -> None:
+        client = api_module.CameConnectClient(
+            session=None,
+            client_id="client",
+            client_secret="secret",
+            username="user",
+            password="pass",
+            redirect_uri="https://app.cameconnect.net/role",
+        )
+        client.async_get_sip_accounts = AsyncMock(return_value=_extract_bpt_sip_accounts(SAMPLE_SIPACCOUNTS))
+
+        with self.assertRaises(CameApiError) as ctx:
+            await client.async_resolve_bpt_door_config(
+                str(DUMMY_DEVICE_ID),
+                {
+                    CONF_BPT_SIP_PASSWORD: DUMMY_PASSWORD,
+                    CONF_BPT_SIP_USER: "dummy_sip_user_missing",
+                },
+            )
+
+        self.assertIn("/sipaccounts", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bpt_transport.py
+++ b/tests/test_bpt_transport.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import unittest
+
+from _support import ROOT, ensure_custom_component_packages, load_module
+
+ensure_custom_component_packages()
+
+load_module(
+    "custom_components.came_connect.const",
+    ROOT / "custom_components" / "came_connect" / "const.py",
+)
+api_module = load_module(
+    "custom_components.came_connect.api",
+    ROOT / "custom_components" / "came_connect" / "api.py",
+)
+
+BptDoorConfig = api_module.BptDoorConfig
+
+DUMMY_KEYCODE = "EXAMPLEKEYCODE01"
+DUMMY_SIP_USER = "dummy_sip_user_2"
+DUMMY_PASSWORD = "dummy-password"
+DUMMY_SRC_ADDR = "dummy-src-2"
+DUMMY_TARGET_USER = "dummy-target-user"
+DUMMY_PANEL_ADDR = "dummy-panel-addr"
+DUMMY_SUBJECT_LABEL = "Demo Mobile Slot 2"
+DUMMY_DEVICE_TOKEN = "dummy-device-token-1"
+
+
+def _make_config() -> BptDoorConfig:
+    return BptDoorConfig(
+        keycode=DUMMY_KEYCODE,
+        sip_user=DUMMY_SIP_USER,
+        sip_password=DUMMY_PASSWORD,
+        src_addr=DUMMY_SRC_ADDR,
+        target_user=DUMMY_TARGET_USER,
+        panel_addr=DUMMY_PANEL_ADDR,
+        subject_label=DUMMY_SUBJECT_LABEL,
+        device_token=DUMMY_DEVICE_TOKEN,
+    )
+
+
+class BptTransportTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.client = api_module.CameConnectClient(
+            session=None,
+            client_id="client",
+            client_secret="secret",
+            username="user",
+            password="pass",
+            redirect_uri="https://app.cameconnect.net/role",
+        )
+
+    async def test_async_open_bpt_door_keeps_xipregister_status_and_subject(self) -> None:
+        config = _make_config()
+        self.client._request = AsyncMock(return_value=(403, {"error": "forbidden"}))
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch.object(api_module.asyncio, "to_thread", new=fake_to_thread):
+            with patch.object(
+                self.client,
+                "_send_bpt_xml_command",
+                return_value={
+                    "register_status": "SIP/2.0 200 OK",
+                    "message_status": "SIP/2.0 202 Accepted",
+                },
+            ) as send_mock:
+                result = await self.client.async_open_bpt_door(config)
+
+        send_mock.assert_called_once()
+        sent_config, sent_body, sent_subject = send_mock.call_args.args
+        self.assertIs(sent_config, config)
+        self.assertIn("<type>OPEN_DOOR</type>", sent_body)
+        self.assertEqual(
+            sent_subject,
+            api_module._build_subject(config.src_addr, config.panel_addr, config.subject_label),
+        )
+        self.assertEqual(result["xipregister_status"], 403)
+        self.assertEqual(result["message_status"], "SIP/2.0 202 Accepted")
+
+    async def test_async_open_bpt_aux_sends_aux_xml_without_subject(self) -> None:
+        config = _make_config()
+        self.client._request = AsyncMock(return_value=(200, {"ok": True}))
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch.object(api_module.asyncio, "to_thread", new=fake_to_thread):
+            with patch.object(
+                self.client,
+                "_send_bpt_xml_command",
+                return_value={
+                    "register_status": "SIP/2.0 200 OK",
+                    "message_status": "SIP/2.0 202 Accepted",
+                },
+            ) as send_mock:
+                result = await self.client.async_open_bpt_aux(config, 3)
+
+        send_mock.assert_called_once()
+        sent_config, sent_body, sent_subject = send_mock.call_args.args
+        self.assertIs(sent_config, config)
+        self.assertIn("<type>AUX_COMMAND</type>", sent_body)
+        self.assertIn("<aux_code>3</aux_code>", sent_body)
+        self.assertIsNone(sent_subject)
+        self.assertEqual(result["aux_code"], 3)
+        self.assertEqual(result["xipregister_status"], 200)
+
+    def test_build_message_request_omits_subject_when_none(self) -> None:
+        config = _make_config()
+        request = self.client._build_message_request(
+            config,
+            local_ip="192.168.1.2",
+            local_port=5061,
+            call_id="call-id",
+            tag="tag-id",
+            branch="branch-id",
+            cseq=1,
+            subject=None,
+            body="<xml/>",
+        ).decode()
+
+        self.assertIn(f"MESSAGE sip:{DUMMY_TARGET_USER}@{DUMMY_KEYCODE}.xip.cameconnect.net SIP/2.0", request)
+        self.assertNotIn("Subject:", request)
+        self.assertIn("Content-Type: text/xml", request)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import AsyncMock
+
+from _support import (
+    ROOT,
+    ensure_custom_component_packages,
+    install_homeassistant_stubs,
+    install_voluptuous_stub,
+    load_module,
+)
+
+ensure_custom_component_packages()
+install_homeassistant_stubs()
+install_voluptuous_stub()
+
+const_module = load_module(
+    "custom_components.came_connect.const",
+    ROOT / "custom_components" / "came_connect" / "const.py",
+)
+api_module = load_module(
+    "custom_components.came_connect.api",
+    ROOT / "custom_components" / "came_connect" / "api.py",
+)
+config_flow_module = load_module(
+    "custom_components.came_connect.config_flow",
+    ROOT / "custom_components" / "came_connect" / "config_flow.py",
+)
+
+from homeassistant.config_entries import ConfigEntry
+
+BptDeviceMetadata = api_module.BptDeviceMetadata
+BptMobileSlot = api_module.BptMobileSlot
+BptSetupPreview = api_module.BptSetupPreview
+CameConnectOptionsFlow = config_flow_module.CameConnectOptionsFlow
+CONF_BPT_SIP_PASSWORD = const_module.CONF_BPT_SIP_PASSWORD
+CONF_BPT_SIP_USER = const_module.CONF_BPT_SIP_USER
+CONF_CLIENT_ID = const_module.CONF_CLIENT_ID
+CONF_CLIENT_SECRET = const_module.CONF_CLIENT_SECRET
+CONF_DEVICE_ID = const_module.CONF_DEVICE_ID
+CONF_PASSWORD = const_module.CONF_PASSWORD
+CONF_USERNAME = const_module.CONF_USERNAME
+
+DUMMY_DEVICE_ID = "dummy-device-id-1"
+DUMMY_DEVICE_NAME = "Example Indoor Monitor"
+DUMMY_ENTRY_PANEL_NAME = "Example Entry Panel"
+DUMMY_UNIT_NAME = "Example Unit"
+DUMMY_OPEN_DOOR_LABEL = "Example Open Door"
+DUMMY_SIP_USER_ONE = "dummy_sip_user_1"
+DUMMY_SIP_USER_TWO = "dummy_sip_user_2"
+DUMMY_SRC_ADDR_ONE = "dummy-src-1"
+DUMMY_SRC_ADDR_TWO = "dummy-src-2"
+DUMMY_SLOT_ONE_LABEL = "Demo Mobile Slot 1"
+DUMMY_SLOT_TWO_LABEL = "Demo Mobile Slot 2"
+DUMMY_PASSWORD = "dummy-password"
+
+
+def _metadata() -> BptDeviceMetadata:
+    return BptDeviceMetadata(
+        device_name=DUMMY_DEVICE_NAME,
+        entry_panel_name=DUMMY_ENTRY_PANEL_NAME,
+        unit_name=DUMMY_UNIT_NAME,
+        open_door_label=DUMMY_OPEN_DOOR_LABEL,
+        aux_features=(),
+        model="CAME BPT X1",
+    )
+
+
+def _preview(slots: tuple[BptMobileSlot, ...], selected_slot: BptMobileSlot | None = None) -> BptSetupPreview:
+    return BptSetupPreview(
+        slots=slots,
+        selected_slot=selected_slot,
+        metadata=_metadata(),
+        token_source="sipaccounts",
+    )
+
+
+def _flow(options: dict[str, str] | None = None) -> CameConnectOptionsFlow:
+    flow = CameConnectOptionsFlow()
+    flow.hass = object()
+    flow.config_entry = ConfigEntry(
+        data={
+            CONF_CLIENT_ID: "client",
+            CONF_CLIENT_SECRET: "secret",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_DEVICE_ID: DUMMY_DEVICE_ID,
+        },
+        options=options or {},
+        entry_id="entry-id",
+    )
+    return flow
+
+
+def _schema_value(schema, key: str):
+    for marker, value in schema.schema.items():
+        if getattr(marker, "schema", None) == key:
+            return value
+    return None
+
+
+class ConfigFlowTests(unittest.IsolatedAsyncioTestCase):
+    async def test_async_step_bpt_auto_picks_single_slot(self) -> None:
+        slot = BptMobileSlot(
+            sip_user=DUMMY_SIP_USER_TWO,
+            src_addr=DUMMY_SRC_ADDR_TWO,
+            subject_label=DUMMY_SLOT_TWO_LABEL,
+        )
+        flow = _flow()
+        preview = _preview((slot,), selected_slot=slot)
+        flow._async_get_bpt_preview = AsyncMock(return_value=(preview, None))
+
+        result = await flow.async_step_bpt({CONF_BPT_SIP_PASSWORD: DUMMY_PASSWORD})
+
+        self.assertEqual(result["type"], "create_entry")
+        self.assertEqual(result["data"][CONF_BPT_SIP_PASSWORD], DUMMY_PASSWORD)
+        self.assertEqual(result["data"][CONF_BPT_SIP_USER], DUMMY_SIP_USER_TWO)
+
+    async def test_async_step_bpt_requires_selection_when_multiple_slots_exist(self) -> None:
+        slot_one = BptMobileSlot(
+            sip_user=DUMMY_SIP_USER_ONE,
+            src_addr=DUMMY_SRC_ADDR_ONE,
+            subject_label=DUMMY_SLOT_ONE_LABEL,
+        )
+        slot_two = BptMobileSlot(
+            sip_user=DUMMY_SIP_USER_TWO,
+            src_addr=DUMMY_SRC_ADDR_TWO,
+            subject_label=DUMMY_SLOT_TWO_LABEL,
+        )
+        flow = _flow()
+        preview = _preview((slot_one, slot_two))
+        flow._async_get_bpt_preview = AsyncMock(side_effect=[(preview, None), (preview, None)])
+
+        result = await flow.async_step_bpt({CONF_BPT_SIP_PASSWORD: DUMMY_PASSWORD})
+
+        self.assertEqual(result["type"], "form")
+        self.assertEqual(result["errors"]["base"], "slot_required")
+
+    async def test_build_bpt_schema_uses_dropdown_for_multiple_slots(self) -> None:
+        slot_one = BptMobileSlot(
+            sip_user=DUMMY_SIP_USER_ONE,
+            src_addr=DUMMY_SRC_ADDR_ONE,
+            subject_label=DUMMY_SLOT_ONE_LABEL,
+        )
+        slot_two = BptMobileSlot(
+            sip_user=DUMMY_SIP_USER_TWO,
+            src_addr=DUMMY_SRC_ADDR_TWO,
+            subject_label=DUMMY_SLOT_TWO_LABEL,
+        )
+        flow = _flow()
+
+        schema = flow._build_bpt_schema(flow._current_options(), _preview((slot_one, slot_two)))
+        field = _schema_value(schema, CONF_BPT_SIP_USER)
+
+        self.assertIsNotNone(field)
+        self.assertEqual(field.__class__.__name__, "SelectSelector")
+        self.assertEqual(len(field.config.options), 2)
+        self.assertEqual(field.config.options[0]["label"], f"{DUMMY_SLOT_ONE_LABEL} ({DUMMY_SIP_USER_ONE})")
+
+    async def test_build_bpt_placeholders_report_detected_token_source(self) -> None:
+        slot = BptMobileSlot(
+            sip_user=DUMMY_SIP_USER_TWO,
+            src_addr=DUMMY_SRC_ADDR_TWO,
+            subject_label=DUMMY_SLOT_TWO_LABEL,
+        )
+        flow = _flow()
+
+        placeholders = flow._build_bpt_placeholders(_preview((slot,), selected_slot=slot), None)
+
+        self.assertEqual(placeholders["device_name"], DUMMY_DEVICE_NAME)
+        self.assertEqual(placeholders["entry_panel_name"], DUMMY_ENTRY_PANEL_NAME)
+        self.assertEqual(placeholders["open_door_label"], DUMMY_OPEN_DOOR_LABEL)
+        self.assertEqual(placeholders["token_source"], "Detected from /api/sipaccounts")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  This PR adds BPT/X1 cloud SIP integration to the Home Assistant CAME Connect integration.

  It includes:

  - BPT/X1 `Open Door` support
  - discovered AUX button support
  - `/api/sipaccounts`-based BPT bootstrap and slot resolution
  - improved BPT/X1 options flow
  - separate BPT/X1 child device creation in Home Assistant
  - tests for discovery, transport, buttons, and config flow
  - public repo cleanup to keep research, captures, planning, and AI workflow files local-only

  ## User-facing changes

  - Optional BPT/X1 setup is now available from integration options
  - Normal setups usually require only:
    - `Mobile App SIP password`
    - optional `Mobile App slot / SIP user`
  - Home Assistant now creates a separate BPT/X1 device with:
    - `Open Door`
    - discovered AUX buttons when available
  - README and user docs now explain the recommended XTS7/BPT setup flow

  ## Technical notes

  - BPT setup resolves slot and metadata from the authenticated account path
  - `xipregister` `403` is treated as non-fatal for the validated SIP flow
  - TLS fallback is included for HA environments that fail the initial SIP handshake
  - AUX support follows the same validated cloud SIP path as door actuation

  ## Verification

  Ran:

  - `python3 -m py_compile custom_components/came_connect/*.py tests/*.py`
  - `python3 -m unittest discover -s tests -p 'test_*.py'`

  Result:

  - `25` tests passing